### PR TITLE
obs_sequence object aware whether it has assimilation results or not

### DIFF
--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -91,6 +91,17 @@ class obs_sequence:
             else:
                 self.synonyms_for_obs.append(synonyms)
 
+        if file is None:
+            # Early exit for testing purposes
+            self.df = pd.DataFrame()
+            self.types = {}
+            self.reverse_types = {}
+            self.copie_names = []
+            self.n_copies = 0
+            self.seq = []
+            self.all_obs = []
+            return
+
         module_dir = os.path.dirname(__file__)
         self.default_composite_types = os.path.join(module_dir,"composite_types.yaml")
 
@@ -353,7 +364,7 @@ class obs_sequence:
         if dart_qc not in self.df['DART_quality_control'].unique():
             raise ValueError(f"DART quality control flag '{dart_qc}' not found in DataFrame.")
         else:
-            return df[df['DART_quality_control'] == dart_qc]
+            return self.df[self.df['DART_quality_control'] == dart_qc]
 
     @requires_assimilation_info
     def select_failed_qcs(self):

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -46,7 +46,7 @@ class TestOneDimensional:
         obj = obsq.obs_sequence(obs_seq_file_path)
         assert obj.loc_mod == 'loc1d'
         assert len(obj.df) == 40  # 40 obs in the file
-        assert obj.df.columns.str.contains('posterior').sum() == 22 
+        assert obj.df.columns.str.contains('posterior').sum() == 22 + 2  # members + sq_err + bias
         assert obj.df.columns.str.contains('prior').sum() == 22
  
 


### PR DESCRIPTION
* Added two bits of information to the obs_sequence class:
        self.has_assimilation_info = False
        self.has_posterior = False

* An obs_sequence object is then aware of whether it has assimilation info (prior only or prior and posterior)

* Added decorator for class methods that require assimilation to check info is present.  
  Select by qc and possible vs used functions now class methods and use the decorator (because they need assimilation info)

* Now have a posterior bias and sq error column (note I've not renamed bias & sq error to prior_bias, prior sq error)

* Added tests for requires assimilation_info, __init__ method changed so you don’t need a file for testing the data frame routines. 

* Added an early exit if no file is given to obs_sequence::init. This is so you can test the data frame methods without worrying about having a file to give data. 

fixes #25
fixes #27
fixes #19