### PR TITLE
Example of adding external FO to an observation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ build
 docs/examples
 sg_execution_times.rst
 .vscode
-examples/obs_seq*
+examples/**/obs_seq*
 

--- a/data/obs_seq.out.tracer
+++ b/data/obs_seq.out.tracer
@@ -1,0 +1,35 @@
+ obs_sequence
+obs_type_definitions
+           2
+           1 RAW_STATE_VARIABLE             
+           2 RAW_TRACER_CONCENTRATION       
+  num_copies:            2  num_qc:            1
+  num_obs:        2  max_num_obs:        2
+observations                                                    
+truth                                                           
+Quality Control                                                 
+  first:            1  last:        2
+ OBS            1
+   2.0725625157212870     
+   1.6488630019849135     
+   0.0000000000000000     
+          -1           2          -1
+obdef
+loc1d
+   0.0976320288609713
+kind
+           2
+     0          0
+   10.010000000000000     
+ OBS            2
+  0.50940099779359427     
+  0.71515334314452661     
+   0.0000000000000000     
+           1           -1          -1
+obdef
+loc1d
+   0.1116066654212773
+kind
+          1
+     0          0
+   9.9900000000000002     

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ sphinx_gallery_conf = {
      'gallery_dirs': 'examples',  # path to where to save gallery generated output
      'default_thumb_file': default_thumb_file,
      'remove_config_comments': True,
+     'within_subsection_order': 'FileNameSortKey',
 }
 
 pio.renderers.default = 'sphinx_gallery' # for plotly output in examples

--- a/examples/01_manipulating/plot_external_fo.py
+++ b/examples/01_manipulating/plot_external_fo.py
@@ -1,0 +1,68 @@
+"""
+Adding External Forward Operators to an Observation
+===================================================
+
+External, or "precomputed" forward operators are forward operators
+that are not calculated during filter, DART's assimilation program. 
+They are calculated externally, written to an observation sequence file,
+and read it by DART.  
+
+This example shows how to add an external forward operator to an observation.
+We'll be using observations for the Lorenz 96 tracer model, which is a toy
+model used to test assimilation algorithms.  We are going to create some 
+RAW_TRACER_CONCENTRATION forward operators.
+
+"""
+
+###########################################
+# Import the obs_sequence module, and numpy
+import os
+import pydartdiags.obs_sequence.obs_sequence as obsq
+import numpy as np
+
+###########################################
+# Read in the observation sequence file. In this example we'll use the
+# obs_seq.out.tracer file that comes with the pyDARTdiags package.
+# This file only has two observations. 
+data_dir = os.path.join(os.getcwd(), "../..", "data")
+data_file = os.path.join(data_dir, "obs_seq.out.tracer")
+obs_seq = obsq.obs_sequence(data_file)
+
+###########################################
+obs_seq.df
+
+
+###########################################
+# The external forward operator is stored in the 'external_FO' column.
+# Currently, the 'external_FO' column is empty.
+obs_seq.df.iloc[0]['external_FO']
+
+
+###########################################
+# Let's add a forward operator to the RAW_TRACER_CONCENTRATION observation.
+# For this example, we're going to use random numbers to create our ensemble
+# of forward operators. For a scientific experiment, you would use appropriate 
+# forward operator results from your model. 
+# We want 80 ensemble members, so we'll create 80 random numbers, and we want tracer
+# concentrations, so we'll force the numbers to be positive.
+n = 80
+random_numbers = np.abs(np.random.normal(loc=0.75, scale=0.1, size=n)).tolist()
+
+###########################################
+# DART observation sequence files have a specific format. DART expects the list
+# of forward operators to have 'external_FO' followed by the number of ensemble
+# members, followed by the 'key' for the forward operator. The 'key' is not 
+# used by DART, so we will just put 1 for the value. 
+random_numbers.insert(0, f'external_FO {n} 1')
+
+###########################################
+# Now we can add the forward operator to the 'external_FO' column for row 0
+obs_seq.df.at[0,'external_FO'].extend(random_numbers)
+
+###########################################
+# Now the 'external_FO' column has the forward operator.
+obs_seq.df.iloc[0]['external_FO']
+
+###########################################
+# Let's write the observation sequence file with the new forward operator.
+obs_seq.write_obs_seq('obs_seq.out.tracer_with_external_FO')


### PR DESCRIPTION
Lorenz_96 tracer example

simple example: 
- 2 obs
- create external_FO for one of the obs (RAW_TRACER_CONCETRATION)
- write the new sequence to a file

Also changed conf.py sphinx-gallery so the order of the subgallery files is alphabetical. The default is file size. 