### PR TITLE
skip the columns created by stats & bin by level when writing obs sequences

### DIFF
--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -366,8 +366,13 @@ class obs_sequence:
             if self.loc_mod == "loc3d":
                 df_copy["longitude"] = np.deg2rad(self.df["longitude"]).round(16)
                 df_copy["latitude"] = np.deg2rad(self.df["latitude"]).round(16)
-            if "bias" in df_copy.columns:
-                df_copy = df_copy.drop(columns=["bias", "sq_err"])
+            if "prior_bias" in df_copy.columns:
+                df_copy = df_copy.drop(columns=["prior_bias", "prior_sq_err", "prior_totalvar"])
+            if "posterior_bias" in df_copy.columns:
+                df_copy = df_copy.drop(columns=["posterior_bias", "posterior_sq_err", "posterior_totalvar"])
+            if "midpoint" in df_copy.columns:
+                df_copy = df_copy.drop(columns=["midpoint", "vlevels"])
+                  
 
             # linked list for reading by dart programs
             df_copy = df_copy.sort_values(

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -367,12 +367,15 @@ class obs_sequence:
                 df_copy["longitude"] = np.deg2rad(self.df["longitude"]).round(16)
                 df_copy["latitude"] = np.deg2rad(self.df["latitude"]).round(16)
             if "prior_bias" in df_copy.columns:
-                df_copy = df_copy.drop(columns=["prior_bias", "prior_sq_err", "prior_totalvar"])
+                df_copy = df_copy.drop(
+                    columns=["prior_bias", "prior_sq_err", "prior_totalvar"]
+                )
             if "posterior_bias" in df_copy.columns:
-                df_copy = df_copy.drop(columns=["posterior_bias", "posterior_sq_err", "posterior_totalvar"])
+                df_copy = df_copy.drop(
+                    columns=["posterior_bias", "posterior_sq_err", "posterior_totalvar"]
+                )
             if "midpoint" in df_copy.columns:
                 df_copy = df_copy.drop(columns=["midpoint", "vlevels"])
-                  
 
             # linked list for reading by dart programs
             df_copy = df_copy.sort_values(

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -5,6 +5,7 @@ import tempfile
 import datetime as dt
 import pandas as pd
 from pydartdiags.obs_sequence import obs_sequence as obsq
+from pydartdiags.stats import stats
 
 
 class TestConvertDartTime:
@@ -177,6 +178,77 @@ class TestWriteAscii:
 
         # Compare the written file with the reference file, line by line
         self.compare_files_line_by_line(temp_output_file_path, ascii_obs_seq_file_path)
+
+        # Clean up is handled by the temporary directory context manager
+
+    @pytest.mark.parametrize(
+        "obs_seq_file_path",
+        [
+            os.path.join(
+                os.path.dirname(__file__), "data", "obs_seq.final.ascii.small"
+            ),
+            os.path.join(os.path.dirname(__file__), "data", "obs_seq.out.GSI.small"),
+        ],
+    )
+    def test_write_after_stats(self, obs_seq_file_path, temp_dir):
+        # Create a temporary file path for the output
+        temp_output_file_path = os.path.join(
+            temp_dir, "obs_seq.final.ascii.write-after-stats"
+        )
+
+        # Create an instance of the obs_sequence class and write the output file
+        obj = obsq.obs_sequence(obs_seq_file_path)
+        stats.diag_stats(obj.df)  # add the stats columns
+        obj.write_obs_seq(temp_output_file_path)
+
+        # Ensure the output file exists
+        assert os.path.exists(temp_output_file_path)
+
+        # Compare the written file with the reference file, line by line
+        self.compare_files_line_by_line(temp_output_file_path, obs_seq_file_path)
+
+        # Clean up is handled by the temporary directory context manager
+
+    @pytest.mark.parametrize(
+        "obs_seq_file_path",
+        [
+            os.path.join(
+                os.path.dirname(__file__), "data", "obs_seq.final.ascii.small"
+            ),
+            os.path.join(os.path.dirname(__file__), "data", "obs_seq.out.GSI.small"),
+        ],
+    )
+    def test_write_after_bin(self, obs_seq_file_path, temp_dir):
+        # Create a temporary file path for the output
+        temp_output_file_path = os.path.join(
+            temp_dir, "obs_seq.final.ascii.write-after-bin"
+        )
+
+        # Create an instance of the obs_sequence class and write the output file
+        obj = obsq.obs_sequence(obs_seq_file_path)
+        hPalevels = [
+            0.0,
+            100.0,
+            150.0,
+            200.0,
+            250.0,
+            300.0,
+            400.0,
+            500.0,
+            700,
+            850,
+            925,
+            1000,
+        ]  # hPa
+        levels = [i * 100 for i in hPalevels]
+        stats.bin_by_layer(obj.df, levels)  # add the stats columns
+        obj.write_obs_seq(temp_output_file_path)
+
+        # Ensure the output file exists
+        assert os.path.exists(temp_output_file_path)
+
+        # Compare the written file with the reference file, line by line
+        self.compare_files_line_by_line(temp_output_file_path, obs_seq_file_path)
 
         # Clean up is handled by the temporary directory context manager
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -543,7 +543,7 @@ class TestLayers:
         layers = [0, 100, 200, 300]
 
         # Call the function
-        stats.bin_by_layer(df, layers,verticalUnit="height (m)" )
+        stats.bin_by_layer(df, layers, verticalUnit="height (m)")
 
         # Check if the result DataFrame has the expected columns
         expected_columns = [
@@ -597,6 +597,7 @@ class TestLayers:
 
         expected_df = pd.DataFrame(data_result)
         pd.testing.assert_frame_equal(df, expected_df)
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
drop the columns created by the stats module when writing out observation sequences. 
Note the write is a copy of obs_seq.df so the obs_seq.df is not modified by the write. 

columns dropped are
"prior/posterior_bias", "prior/posterior_sq_err", "prior/posterior_totalvar", "midpoint" , "vlevels"

tests added:
 - run stats then write
 - bin by level then write (on obs_seq.out and obs_seq.final)

fixes: #49 