### PR TITLE
used observations should include QC=2

### DIFF
--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -438,14 +438,16 @@ class obs_sequence:
             return self.df[self.df["DART_quality_control"] == dart_qc]
 
     @requires_assimilation_info
-    def select_failed_qcs(self):
+    def select_used_qcs(self):
         """
-        Select rows from the DataFrame where the DART quality control flag is greater than 0.
+        Select rows from the DataFrame where the observation was used.
+        Includes observations for which the posterior forward observation operators failed.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing only the rows with a DART quality control flag greater than 0.
+            pandas.DataFrame: A DataFrame containing only the rows with a DART quality control flag 0 or 2.
         """
-        return self.df[self.df["DART_quality_control"] > 0]
+        return self.df[(self.df["DART_quality_control"] == 0) 
+                       | (self.df["DART_quality_control"] == 2)]
 
     @requires_assimilation_info
     def possible_vs_used(self):
@@ -454,7 +456,7 @@ class obs_sequence:
 
         This function takes a DataFrame containing observation data, including a 'type' column for the observation
         type and an 'observation' column. The number of used observations ('used'), is the total number
-        minus the observations that failed quality control checks (as determined by the `select_failed_qcs` function).
+        of assimilated observations (as determined by the `select_used_qcs` function).
         The result is a DataFrame with each observation type, the count of possible observations, and the count of
         used observations.
 
@@ -466,8 +468,8 @@ class obs_sequence:
         possible = self.df.groupby("type")["observation"].count()
         possible.rename("possible", inplace=True)
 
-        failed_qcs = self.select_failed_qcs().groupby("type")["observation"].count()
-        used = possible - failed_qcs.reindex(possible.index, fill_value=0)
+        used_qcs = self.select_used_qcs().groupby("type")["observation"].count()
+        used = used_qcs.reindex(possible.index, fill_value=0)
         used.rename("used", inplace=True)
 
         return pd.concat([possible, used], axis=1).reset_index()

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -446,8 +446,10 @@ class obs_sequence:
         Returns:
             pandas.DataFrame: A DataFrame containing only the rows with a DART quality control flag 0 or 2.
         """
-        return self.df[(self.df["DART_quality_control"] == 0) 
-                       | (self.df["DART_quality_control"] == 2)]
+        return self.df[
+            (self.df["DART_quality_control"] == 0)
+            | (self.df["DART_quality_control"] == 2)
+        ]
 
     @requires_assimilation_info
     def possible_vs_used(self):

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -311,7 +311,7 @@ class TestObsDataframe:
         expected_data = {
             "type": ["type1", "type2", "type3"],
             "possible": [3, 2, 1],
-            "used": [2, 0, 1],
+            "used": [3, 0, 1],
         }
         expected_df = pd.DataFrame(expected_data)
 

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -288,16 +288,16 @@ class TestObsDataframe:
         # Assert that the result matches the expected DataFrame, ignoring the index
         pd.testing.assert_frame_equal(result, expected_df)
 
-    def test_select_failed_qcs(self, obs_seq):
-        result = obs_seq.select_failed_qcs().reset_index(drop=True)
+    def test_select_used_qcs(self, obs_seq):
+        result = obs_seq.select_used_qcs().reset_index(drop=True)
 
         # Expected DataFrame
         expected_data = {
-            "DART_quality_control": [1, 2, 3],
-            "type": ["type2", "type1", "type2"],
-            "observation": [2.0, 3.0, 5.0],
-            "prior_ensemble_mean": [2.1, 3.1, 5.1],
-            "prior_ensemble_spread": [0.2, 0.3, 0.5],
+            "DART_quality_control": [0, 2, 0, 0],
+            "type": ["type1", "type1", "type3", "type1"],
+            "observation": [1.0, 3.0, 4.0, 5.2],
+            "prior_ensemble_mean": [1.1, 3.1, 4.1, 5.3],
+            "prior_ensemble_spread": [0.1, 0.3, 0.4, 0.6],
         }
         expected_df = pd.DataFrame(expected_data)
 


### PR DESCRIPTION
Fixes #53.
Observations with QC=2 were treated as unused by `possible_vs_used`, but they are assimilated. It's just that there is(are) no posterior observation space value(s).