### PR TITLE
Fix used obs in matplots

### DIFF
--- a/examples/03_diagnostics/plot_profiles.py
+++ b/examples/03_diagnostics/plot_profiles.py
@@ -26,14 +26,10 @@ data_file = os.path.join(data_dir, "obs_seq.final.1000")
 obs_seq = obsq.obs_sequence(data_file)
 
 ###########################################
-# Select observations with QC value of 0.
-qc0 = obs_seq.select_by_dart_qc(0)
-
-###########################################
 # Chose an observation type.
 # The observation types are stored in the 'type' column.
 # To see which observation types are in the dataframe, use the unique method:
-qc0['type'].unique()
+obs_seq.df['type'].unique()
 
 ###########################################
 # For this example, we are going to look at the rank histogram for 

--- a/examples/03_diagnostics/plot_rank_histogram.py
+++ b/examples/03_diagnostics/plot_rank_histogram.py
@@ -27,14 +27,10 @@ data_file = os.path.join(data_dir, "obs_seq.final.1000")
 obs_seq = obsq.obs_sequence(data_file)
 
 ###########################################
-# Select observations with QC value of 0.
-qc0 = obs_seq.select_by_dart_qc(0)
-
-###########################################
 # Chose an observation type.
 # The observation types are stored in the 'type' column.
 # To see which observation types are in the dataframe, use the unique method:
-qc0['type'].unique()
+obs_seq.df['type'].unique()
 
 ###########################################
 # For this example, we are going to look at the rank histogram for 

--- a/src/pydartdiags/matplots/matplots.py
+++ b/src/pydartdiags/matplots/matplots.py
@@ -29,7 +29,7 @@ def plot_profile(obs_seq, levels, type, bias=True, rmse=True, totalspread=True):
 
     # calculate stats and add to dataframe
     stats.diag_stats(obs_seq.df)
-    qc0 = obs_seq.select_by_dart_qc(0)  # filter only qc=0
+    qc0 = stats.select_used_qcs(obs_seq.df)  # filter only qc=0, qc=2
 
     # filter by type
     qc0 = qc0[qc0["type"] == type]
@@ -228,7 +228,7 @@ def plot_profile(obs_seq, levels, type, bias=True, rmse=True, totalspread=True):
 
 def plot_rank_histogram(obs_seq, levels, type, ens_size):
 
-    qc0 = obs_seq.select_by_dart_qc(0)  # filter only qc=0
+    qc0 = stats.select_used_qcs(obs_seq.df)  # filter only qc=0, qc=2
     qc0 = qc0[qc0["type"] == type]  # filter by type
     stats.bin_by_layer(qc0, levels)  # bin by level
 


### PR DESCRIPTION
stats.select_used_qcs(obs_seq.df) vs just qc0

Updated examples for diagnostics plots, no need to do any qc selection before calling the plotting. Its misleading to have the select by qc0 (and also wrong even if you did have to do that - need 0 & 2)