### PR TITLE
Grammar and typo fixes, and links to statistics documentation in the examples

### DIFF
--- a/examples/01_manipulating/plot_external_fo.py
+++ b/examples/01_manipulating/plot_external_fo.py
@@ -3,9 +3,9 @@ Adding External Forward Operators to an Observation
 ===================================================
 
 External, or "precomputed" forward operators are forward operators
-that are not calculated during filter, DART's assimilation program. 
+that are not calculated during ``filter``, DART's assimilation program. 
 They are calculated externally, written to an observation sequence file,
-and read it by DART.  
+and read in by ``filter``.  
 
 This example shows how to add an external forward operator to an observation.
 We'll be using observations for the Lorenz 96 tracer model, which is a toy

--- a/examples/02_visualizing/plot_qc_hover.py
+++ b/examples/02_visualizing/plot_qc_hover.py
@@ -2,8 +2,8 @@
 Geographic Plot of Observations to look at QC
 ==============================================
 
-This example demonstrates how to read and observation sequence
-file, and plot the observations on a map, with the color
+This example demonstrates how to read an observation sequence
+file and plot the observations on a map, with the color
 indicating the QC value.
 
 

--- a/examples/03_diagnostics/plot_grand_stats.py
+++ b/examples/03_diagnostics/plot_grand_stats.py
@@ -3,13 +3,14 @@ Grand Statistics
 ================
 
 This example demonstrates how to compute grand statistics for
-an observation sequence.
+an observation sequence. For an explanation of the statistics calculations see
+the :ref:`statistics` guide.
 
 """
 
 ###########################################
 # Import the obs_sequence module 
-# and the statistics module
+# and the statistics module.
 import pydartdiags.obs_sequence.obs_sequence as obsq
 from pydartdiags.stats import stats
 ###########################################
@@ -23,20 +24,20 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 
 ###########################################
-# Read the obs_seq file into an obs_seq object
+# Read the obs_seq file into an obs_seq object.
 obs_seq = obsq.obs_sequence(data_file)
 
-# Select observations that were used in the assimilation
+# Select observations that were used in the assimilation.
 used_obs = obs_seq.select_used_qcs()
 
 ###########################################
 # `used_obs` is a dataframe with only the observations with QC value of 0.
 #
-# The columns of the dataframe are the same as the original obs_seq dataframe
+# The columns of the dataframe are the same as the original obs_seq dataframe.
 used_obs.columns
 
 ###########################################
-# Now we calculate the statistics required for DART diagnostics
+# Now we calculate the statistics required for DART diagnostics.
 
 stats.diag_stats(used_obs)
 
@@ -48,7 +49,7 @@ used_obs.columns
 
 ###########################################
 # The help function can be used to find out more about the diag_stats function
-# including what statistics are calculated
+# including what statistics are calculated.
 help(stats.diag_stats)
 
 

--- a/examples/03_diagnostics/plot_grand_stats.py
+++ b/examples/03_diagnostics/plot_grand_stats.py
@@ -26,25 +26,25 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 # Read the obs_seq file into an obs_seq object
 obs_seq = obsq.obs_sequence(data_file)
 
-# Select observations with QC value of 0
-qc0 = obs_seq.select_by_dart_qc(0)
+# Select observations that were used in the assimilation
+used_obs = obs_seq.select_used_qcs()
 
 ###########################################
-# qc0 is a dataframe with only the observations with QC value of 0.
+# `used_obs` is a dataframe with only the observations with QC value of 0.
 #
 # The columns of the dataframe are the same as the original obs_seq dataframe
-qc0.columns
+used_obs.columns
 
 ###########################################
 # Now we calculate the statistics required for DART diagnostics
 
-stats.diag_stats(qc0)
+stats.diag_stats(used_obs)
 
 ###########################################
 # The statistics are calculated for each row in the dataframe, 
 # and the results are stored in new columns.
 
-qc0.columns
+used_obs.columns
 
 ###########################################
 # The help function can be used to find out more about the diag_stats function
@@ -55,4 +55,4 @@ help(stats.diag_stats)
 ###########################################
 # Summarize the grand statistics, which are the statistics aggregated over all the observations
 # for each type of observation.
-stats.grand_statistics(qc0)
+stats.grand_statistics(used_obs)

--- a/examples/03_diagnostics/plot_profiles.py
+++ b/examples/03_diagnostics/plot_profiles.py
@@ -3,7 +3,8 @@ Plot Profiles
 =============
 
 This example demonstrates how to plot profiles of 
-RMSE, bias, and totalspread.
+RMSE, bias, and totalspread. For an explanation of the statistics calculations see
+the :ref:`statistics` guide.
 """
 
 ###########################################

--- a/src/pydartdiags/matplots/matplots.py
+++ b/src/pydartdiags/matplots/matplots.py
@@ -46,7 +46,6 @@ def plot_profile(obs_seq, levels, type, bias=True, rmse=True, totalspread=True):
         return None
 
     vert_unit = all_df.iloc[0]["vert_unit"]
-    print("Vertical unit: ", vert_unit)
     if vert_unit == "pressure (Pa)":
         conversion = 0.01  # from Pa to hPa
     else:


### PR DESCRIPTION
Grammar and typo fixes, and links to statistics documentation in the examples.
Removed a stray print of the vertical unit from plot_profile.
