### PR TITLE
rename obs_sequence class to ObsSequence

### DIFF
--- a/examples/01_manipulating/plot_duplicates.py
+++ b/examples/01_manipulating/plot_duplicates.py
@@ -19,7 +19,7 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "NCEP+ACARS.201303_6H.obs_seq2013030306")
 
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 # How many observations are in the sequence?

--- a/examples/01_manipulating/plot_external_fo.py
+++ b/examples/01_manipulating/plot_external_fo.py
@@ -26,7 +26,7 @@ import numpy as np
 # This file only has two observations. 
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.out.tracer")
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 obs_seq.df

--- a/examples/01_manipulating/plot_join_obs_seq.py
+++ b/examples/01_manipulating/plot_join_obs_seq.py
@@ -22,7 +22,7 @@ data_file1 = os.path.join(data_dir, "obs_seq.final.1000")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq1 = obsq.obs_sequence(data_file1)
+obs_seq1 = obsq.ObsSequence(data_file1)
 
 print('obs_seq1 has assimilation info:', obs_seq1.has_assimilation_info())
 print('obs_seq1 has posterior:', obs_seq1.has_posterior())
@@ -31,7 +31,7 @@ print('obs_seq1 has posterior:', obs_seq1.has_posterior())
 # Chose the second obs_seq file to read.
 
 data_file2 = os.path.join(data_dir, "obs_seq.final.ascii.small")
-obs_seq2 = obsq.obs_sequence(data_file2)
+obs_seq2 = obsq.ObsSequence(data_file2)
 
 print('obs_seq2 has assimilation info:', obs_seq2.has_assimilation_info())
 print('obs_seq2 has posterior:', obs_seq2.has_posterior())
@@ -50,7 +50,7 @@ print('obs_seq1 has posterior:', obs_seq1.has_posterior())
 # on the obs_sequence class, which
 # we've imported as obsq. The method takes a list of obs_seq objects to join.
 
-obs_seq_mega = obsq.obs_sequence.join([obs_seq1, obs_seq2])
+obs_seq_mega = obsq.ObsSequence.join([obs_seq1, obs_seq2])
 
 print(f'length of obs_seq1: {len(obs_seq1.df)}'), print(f'length of obs_seq2: {len(obs_seq2.df)}')
 print(f'length of obs_seq_mega: {len(obs_seq_mega.df)}')
@@ -69,7 +69,7 @@ obs_seq_mega.df.columns
 # and discard the rest of the columns from the obs_seq objects,
 # you can do so like this:
 
-obs_seq_no_members = obsq.obs_sequence.join([obs_seq1, obs_seq2], 
+obs_seq_no_members = obsq.ObsSequence.join([obs_seq1, obs_seq2], 
                                             ['prior_ensemble_mean', 
                                              'prior_ensemble_spread'])
 

--- a/examples/01_manipulating/plot_remove_obs.py
+++ b/examples/01_manipulating/plot_remove_obs.py
@@ -22,7 +22,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 # Take a look at the observation sequence.

--- a/examples/02_visualizing/plot_qc_hover.py
+++ b/examples/02_visualizing/plot_qc_hover.py
@@ -28,7 +28,7 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 
 ###########################################

--- a/examples/03_diagnostics/plot_evolution.py
+++ b/examples/03_diagnostics/plot_evolution.py
@@ -24,7 +24,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.lorenz_96")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 fig = mp.plot_evolution(

--- a/examples/03_diagnostics/plot_grand_stats.py
+++ b/examples/03_diagnostics/plot_grand_stats.py
@@ -25,7 +25,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 # Select observations that were used in the assimilation.
 used_obs = obs_seq.select_used_qcs()

--- a/examples/03_diagnostics/plot_profiles.py
+++ b/examples/03_diagnostics/plot_profiles.py
@@ -24,7 +24,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.1000")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 # Chose an observation type.

--- a/examples/03_diagnostics/plot_qc_poss_vs_used.py
+++ b/examples/03_diagnostics/plot_qc_poss_vs_used.py
@@ -24,7 +24,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.small")
 
 ###########################################
 # read the obs_seq file into an obs_seq object
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 
 ###########################################

--- a/examples/03_diagnostics/plot_rank_histogram.py
+++ b/examples/03_diagnostics/plot_rank_histogram.py
@@ -24,7 +24,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.1000")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-obs_seq = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
 
 ###########################################
 # Chose an observation type.

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -19,10 +19,10 @@ def requires_assimilation_info(func):
     return wrapper
 
 
-class obs_sequence:
+class ObsSequence:
     """
-    Initialize an obs_sequence object from an ASCII or binary observation sequence file,
-    or create an empty obs_sequence object from scratch.
+    Initialize an ObsSequence object from an ASCII or binary observation sequence file,
+    or create an empty ObsSequence object from scratch.
 
     1D observations are given a datetime of days, seconds since 2000-01-01 00:00:00
 
@@ -30,7 +30,7 @@ class obs_sequence:
 
     Args:
         file (str): The input observation sequence ASCII or binary file.
-            If None, an empty obs_sequence object is created from scratch.
+            If None, an empty ObsSequence object is created from scratch.
         synonyms (list, optional): List of additional synonyms for the observation column in the DataFrame.
             The default list is
 
@@ -44,11 +44,11 @@ class obs_sequence:
                 'WOD observation']
 
             You can add more synonyms by providing a list of strings when
-            creating the obs_sequence object.
+            creating the ObsSequence object.
 
             .. code-block:: python
 
-                obs_sequence(file, synonyms=['synonym1', 'synonym2'])
+                ObsSequence(file, synonyms=['synonym1', 'synonym2'])
 
     Raises:
         ValueError: If neither 'loc3d' nor 'loc1d' could be found in the observation sequence.
@@ -57,7 +57,7 @@ class obs_sequence:
 
         .. code-block:: python
 
-            obs_seq = obs_sequence(file='obs_seq.final')
+            obs_seq = ObsSequence(file='obs_seq.final')
 
 
     Attributes:
@@ -92,9 +92,9 @@ class obs_sequence:
 
         seq (generator): Generator of observations from the observation sequence file.
         all_obs (list): List of all observations, each observation is a list.
-            Valid when the obs_sequence is created from a file.
-            Set to None when the obs_sequence is created from scratch or multiple
-            obs_sequences are joined.
+            Valid when the ObsSequence is created from a file.
+            Set to None when the ObsSequence is created from scratch or multiple
+            ObsSequences are joined.
     """
 
     vert = {
@@ -206,7 +206,7 @@ class obs_sequence:
             data.append(float(location[0]))  # location x
             data.append(float(location[1]))  # location y
             data.append(float(location[2]))  # location z
-            data.append(obs_sequence.vert[int(location[3])])
+            data.append(ObsSequence.vert[int(location[3])])
             self.loc_mod = "loc3d"
         except ValueError:
             try:
@@ -364,7 +364,7 @@ class obs_sequence:
             )  # sort the DataFrame by time
             df_copy.reset_index(drop=True, inplace=True)
             df_copy["obs_num"] = df_copy.index + 1  # obs_num in time order
-            df_copy["linked_list"] = obs_sequence.generate_linked_list_pattern(
+            df_copy["linked_list"] = ObsSequence.generate_linked_list_pattern(
                 len(df_copy)
             )  # linked list pattern
 
@@ -586,7 +586,7 @@ class obs_sequence:
         with open(file, "rb") as f:
             while True:
                 # Read the record length
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:
                     break
                 record = f.read(record_length)
@@ -594,7 +594,7 @@ class obs_sequence:
                     break
 
                 # Read the trailing record length (should match the leading one)
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 linecount += 1
 
@@ -612,7 +612,7 @@ class obs_sequence:
             f.seek(0)
 
             for _ in range(2):
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:
                     break
 
@@ -620,7 +620,7 @@ class obs_sequence:
                 if not record:  # end of file
                     break
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
                 header.append(record.decode("utf-8").strip())
 
             header.append(str(obs_types_definitions))
@@ -628,7 +628,7 @@ class obs_sequence:
             # obs_types_definitions
             for _ in range(3, 4 + obs_types_definitions):
                 # Read the record length
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:
                     break
 
@@ -637,7 +637,7 @@ class obs_sequence:
                 if not record:  # end of file
                     break
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 if _ == 3:
                     continue  # num obs_types_definitions
@@ -655,7 +655,7 @@ class obs_sequence:
                 5 + obs_types_definitions + num_copies + num_qcs + 1,
             ):
                 # Read the record length
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:
                     break
 
@@ -664,7 +664,7 @@ class obs_sequence:
                 if not record:
                     break
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 if _ == 5 + obs_types_definitions:
                     continue
@@ -675,12 +675,12 @@ class obs_sequence:
 
             # first and last obs
             # Read the record length
-            record_length = obs_sequence.read_record_length(f)
+            record_length = ObsSequence.read_record_length(f)
 
             # Read the actual record
             record = f.read(record_length)
 
-            obs_sequence.check_trailing_record_length(f, record_length)
+            ObsSequence.check_trailing_record_length(f, record_length)
 
             # Read the whole record as a two integers
             first, last = struct.unpack("ii", record)[:8]
@@ -805,7 +805,7 @@ class obs_sequence:
             # Skip the first len(obs_seq.header) lines
             for _ in range(header_length - 1):
                 # Read the record length
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:  # End of file
                     break
 
@@ -822,7 +822,7 @@ class obs_sequence:
                 obs.append(f"OBS        {obs_num}")
                 for _ in range(n):  # number of copies
                     # Read the record length
-                    record_length = obs_sequence.read_record_length(f)
+                    record_length = ObsSequence.read_record_length(f)
                     if record_length is None:
                         break
                     # Read the actual record (copie)
@@ -830,10 +830,10 @@ class obs_sequence:
                     obs.append(struct.unpack("d", record)[0])
 
                     # Read the trailing record length (should match the leading one)
-                    obs_sequence.check_trailing_record_length(f, record_length)
+                    ObsSequence.check_trailing_record_length(f, record_length)
 
                 # linked list info
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 if record_length is None:
                     break
 
@@ -842,17 +842,17 @@ class obs_sequence:
                 linked_list_string = f"{int1:<12} {int2:<10} {int3:<12}"
                 obs.append(linked_list_string)
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 # location (note no location header "loc3d" or "loc1d" for binary files)
                 obs.append("loc3d")
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 record = f.read(record_length)
                 x, y, z, vert = struct.unpack("dddi", record[:28])
                 location_string = f"{x} {y} {z} {vert}"
                 obs.append(location_string)
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 #   kind (type of observation) value
                 obs.append("kind")
@@ -862,23 +862,23 @@ class obs_sequence:
                 kind = f"{struct.unpack('i', record)[0]}"
                 obs.append(kind)
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 # time (seconds, days)
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 record = f.read(record_length)
                 seconds, days = struct.unpack("ii", record)[:8]
                 time_string = f"{seconds} {days}"
                 obs.append(time_string)
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 # obs error variance
-                record_length = obs_sequence.read_record_length(f)
+                record_length = ObsSequence.read_record_length(f)
                 record = f.read(record_length)
                 obs.append(struct.unpack("d", record)[0])
 
-                obs_sequence.check_trailing_record_length(f, record_length)
+                ObsSequence.check_trailing_record_length(f, record_length)
 
                 yield obs
 
@@ -933,40 +933,40 @@ class obs_sequence:
         return
 
     @classmethod
-    def join(cls, obs_sequences, copies=None):
+    def join(cls, ObsSequences, copies=None):
         """
         Join a list of observation sequences together.
 
-        This method combines the headers and observations from a list of obs_sequence objects
-        into a single obs_sequence object.
+        This method combines the headers and observations from a list of ObsSequence objects
+        into a single ObsSequence object.
 
         Args:
-            obs_sequences (list of obs_sequences): The list of observation sequences objects to join.
+            ObsSequences (list of ObsSequences): The list of observation sequences objects to join.
             copies (list of str, optional): A list of copy names to include in the combined data.
                     If not provided, all copies are included.
 
         Returns:
-            A new obs_sequence object containing the combined data.
+            A new ObsSequence object containing the combined data.
 
         Example:
             .. code-block:: python
 
-                obs_seq1 = obs_sequence(file='obs_seq1.final')
-                obs_seq2 = obs_sequence(file='obs_seq2.final')
-                obs_seq3 = obs_sequence(file='obs_seq3.final')
-                combined = obs_sequence.join([obs_seq1, obs_seq2, obs_seq3])
+                obs_seq1 = ObsSequence(file='obs_seq1.final')
+                obs_seq2 = ObsSequence(file='obs_seq2.final')
+                obs_seq3 = ObsSequence(file='obs_seq3.final')
+                combined = ObsSequence.join([obs_seq1, obs_seq2, obs_seq3])
         """
-        if not obs_sequences:
+        if not ObsSequences:
             raise ValueError("The list of observation sequences is empty.")
 
         # Create a new obs_sequnece object with the combined data
         combo = cls(file=None)
 
-        # Check if all obs_sequences have compatible attributes
-        first_loc_mod = obs_sequences[0].loc_mod
-        first_has_assimilation_info = obs_sequences[0].has_assimilation_info()
-        first_has_posterior = obs_sequences[0].has_posterior()
-        for obs_seq in obs_sequences:
+        # Check if all ObsSequences have compatible attributes
+        first_loc_mod = ObsSequences[0].loc_mod
+        first_has_assimilation_info = ObsSequences[0].has_assimilation_info()
+        first_has_posterior = ObsSequences[0].has_posterior()
+        for obs_seq in ObsSequences:
             if obs_seq.loc_mod != first_loc_mod:
                 raise ValueError(
                     "All observation sequences must have the same loc_mod."
@@ -1008,7 +1008,7 @@ class obs_sequence:
                 + end_required_columns
             )
 
-            for obs_seq in obs_sequences:
+            for obs_seq in ObsSequences:
                 if not set(requested_columns).issubset(obs_seq.df.columns):
                     raise ValueError(
                         "All observation sequences must have the selected copies."
@@ -1037,12 +1037,12 @@ class obs_sequence:
             combo.non_qc_copie_names = [
                 item
                 for item in combo.copie_names
-                if item in obs_sequences[0].non_qc_copie_names
+                if item in ObsSequences[0].non_qc_copie_names
             ]
             combo.qc_copie_names = [
                 item
                 for item in combo.copie_names
-                if item in obs_sequences[0].qc_copie_names
+                if item in ObsSequences[0].qc_copie_names
             ]
 
             combo.n_copies = len(combo.copie_names)
@@ -1050,15 +1050,15 @@ class obs_sequence:
             combo.n_non_qc = len(combo.non_qc_copie_names)
 
         else:
-            for obs_seq in obs_sequences:
-                if not obs_sequences[0].df.columns.isin(obs_seq.df.columns).all():
+            for obs_seq in ObsSequences:
+                if not ObsSequences[0].df.columns.isin(obs_seq.df.columns).all():
                     raise ValueError(
                         "All observation sequences must have the same copies."
                     )
-            combo.n_copies = obs_sequences[0].n_copies
-            combo.n_qc = obs_sequences[0].n_qc
-            combo.n_non_qc = obs_sequences[0].n_non_qc
-            combo.copie_names = obs_sequences[0].copie_names
+            combo.n_copies = ObsSequences[0].n_copies
+            combo.n_qc = ObsSequences[0].n_qc
+            combo.n_non_qc = ObsSequences[0].n_non_qc
+            combo.copie_names = ObsSequences[0].copie_names
 
         # todo HK @todo combine synonyms for obs?
 
@@ -1068,7 +1068,7 @@ class obs_sequence:
         combo.all_obs = None  # set to none to force writing from the dataframe if write_obs_seq is called
 
         # Iterate over the list of observation sequences and combine their data
-        for obs_seq in obs_sequences:
+        for obs_seq in ObsSequences:
             if copies:
                 combined_df = pd.concat(
                     [combined_df, obs_seq.df[requested_columns]], ignore_index=True
@@ -1084,7 +1084,7 @@ class obs_sequence:
 
         # create linked list for obs
         combo.df = combined_df.sort_values(by="time").reset_index(drop=True)
-        combo.df["linked_list"] = obs_sequence.generate_linked_list_pattern(
+        combo.df["linked_list"] = ObsSequence.generate_linked_list_pattern(
             len(combo.df)
         )
         combo.df["obs_num"] = combined_df.index + 1
@@ -1117,7 +1117,7 @@ class obs_sequence:
         )
 
     def create_header(self, n):
-        """Create a header for the obs_seq file from the obs_sequence object."""
+        """Create a header for the obs_seq file from the ObsSequence object."""
         assert (
             self.n_copies == self.n_non_qc + self.n_qc
         ), "n_copies must be equal to n_non_qc + n_qc"

--- a/src/pydartdiags/stats/stats.py
+++ b/src/pydartdiags/stats/stats.py
@@ -4,8 +4,6 @@ import numpy as np
 from functools import wraps
 from datetime import datetime, timedelta
 
-# from pydartdiags.obs_sequence import obs_sequence as obsq
-
 
 def apply_to_phases_in_place(func):
     """

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -43,7 +43,7 @@ class TestSanitizeInput:
             ValueError,
             match="Neither 'loc3d' nor 'loc1d' could be found in the observation sequence.",
         ):
-            obj = obsq.obs_sequence(bad_loc_file_path)
+            obj = obsq.ObsSequence(bad_loc_file_path)
 
 
 class TestOneDimensional:
@@ -53,7 +53,7 @@ class TestOneDimensional:
         return os.path.join(test_dir, "data", "obs_seq.1d.final")
 
     def test_read1d(self, obs_seq_file_path):
-        obj = obsq.obs_sequence(obs_seq_file_path)
+        obj = obsq.ObsSequence(obs_seq_file_path)
         assert obj.loc_mod == "loc1d"
         assert len(obj.df) == 40  # 40 obs in the file
         assert (
@@ -69,11 +69,11 @@ class TestSynonyms:
         return os.path.join(test_dir, "data", "obs_seq.final.ascii.syn")
 
     def test_single(self, synonym_file_path):
-        obj1 = obsq.obs_sequence(synonym_file_path, synonyms="observationx")
+        obj1 = obsq.ObsSequence(synonym_file_path, synonyms="observationx")
         assert "observationx" in obj1.synonyms_for_obs
 
     def test_list(self, synonym_file_path):
-        obj2 = obsq.obs_sequence(
+        obj2 = obsq.ObsSequence(
             synonym_file_path, synonyms=["synonym1", "synonym2", "observationx"]
         )
         assert "synonym1" in obj2.synonyms_for_obs
@@ -87,7 +87,7 @@ class TestBinaryObsSequence:
         return os.path.join(test_dir, "data", "obs_seq.final.binary.small")
 
     def test_read_binary(self, binary_obs_seq_file_path):
-        obj = obsq.obs_sequence(binary_obs_seq_file_path)
+        obj = obsq.ObsSequence(binary_obs_seq_file_path)
         assert len(obj.df) > 0  # Ensure the DataFrame is not empty
 
 
@@ -172,7 +172,7 @@ class TestWriteAscii:
         temp_output_file_path = os.path.join(temp_dir, "obs_seq.final.ascii.write")
 
         # Create an instance of the obs_sequence class and write the output file
-        obj = obsq.obs_sequence(ascii_obs_seq_file_path)
+        obj = obsq.ObsSequence(ascii_obs_seq_file_path)
         obj.write_obs_seq(temp_output_file_path)
 
         # Ensure the output file exists
@@ -199,7 +199,7 @@ class TestWriteAscii:
         )
 
         # Create an instance of the obs_sequence class and write the output file
-        obj = obsq.obs_sequence(obs_seq_file_path)
+        obj = obsq.ObsSequence(obs_seq_file_path)
         stats.diag_stats(obj.df)  # add the stats columns
         obj.write_obs_seq(temp_output_file_path)
 
@@ -227,7 +227,7 @@ class TestWriteAscii:
         )
 
         # Create an instance of the obs_sequence class and write the output file
-        obj = obsq.obs_sequence(obs_seq_file_path)
+        obj = obsq.ObsSequence(obs_seq_file_path)
         hPalevels = [
             0.0,
             100.0,
@@ -264,7 +264,7 @@ class TestWriteAscii:
         obs_seq_file_path = os.path.join(
             os.path.dirname(__file__), "data", "obs_seq.final.ascii.small"
         )
-        obj = obsq.obs_sequence(obs_seq_file_path)
+        obj = obsq.ObsSequence(obs_seq_file_path)
 
         # Remove obs except ACARS_TEMPERATURE
         obj.df = obj.df[(obj.df["type"] == "ACARS_TEMPERATURE")]
@@ -297,7 +297,7 @@ class TestObsDataframe:
         df = pd.DataFrame(data)
 
         # Create an instance of ObsSequence with the sample DataFrame
-        obs_seq = obsq.obs_sequence(file=None)
+        obs_seq = obsq.ObsSequence(file=None)
         obs_seq.df = df
         return obs_seq
 
@@ -394,15 +394,15 @@ class TestJoin:
         with pytest.raises(
             ValueError, match="The list of observation sequences is empty."
         ):
-            obsq.obs_sequence.join([])
+            obsq.ObsSequence.join([])
 
     def test_join_diff_locs(self, obs_seq1d_file_path, binary_obs_seq_file_path):
-        obj1 = obsq.obs_sequence(obs_seq1d_file_path)
-        obj2 = obsq.obs_sequence(binary_obs_seq_file_path)
+        obj1 = obsq.ObsSequence(obs_seq1d_file_path)
+        obj2 = obsq.ObsSequence(binary_obs_seq_file_path)
         with pytest.raises(
             ValueError, match="All observation sequences must have the same loc_mod."
         ):
-            obsq.obs_sequence.join([obj1, obj2])
+            obsq.ObsSequence.join([obj1, obj2])
 
     def test_join_three_obs_seqs(
         self,
@@ -410,10 +410,10 @@ class TestJoin:
         ascii_obs_seq_file_path2,
         ascii_obs_seq_file_path3,
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj2 = obsq.obs_sequence(ascii_obs_seq_file_path2)
-        obj3 = obsq.obs_sequence(ascii_obs_seq_file_path3)
-        obs_seq_mega = obsq.obs_sequence.join([obj1, obj2, obj3])
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj2 = obsq.ObsSequence(ascii_obs_seq_file_path2)
+        obj3 = obsq.ObsSequence(ascii_obs_seq_file_path3)
+        obs_seq_mega = obsq.ObsSequence.join([obj1, obj2, obj3])
 
         assert obs_seq_mega.all_obs == None
         assert len(obs_seq_mega.df) == 16  # obs in the dataframe
@@ -457,9 +457,9 @@ class TestJoin:
     def test_join_list_sub_copies(
         self, ascii_obs_seq_file_path1, ascii_obs_seq_file_path3
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj3 = obsq.obs_sequence(ascii_obs_seq_file_path3)
-        obs_seq_mega = obsq.obs_sequence.join(
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj3 = obsq.ObsSequence(ascii_obs_seq_file_path3)
+        obs_seq_mega = obsq.ObsSequence.join(
             [obj1, obj3], ["prior_ensemble_mean", "observation", "Data_QC"]
         )
 
@@ -475,9 +475,9 @@ class TestJoin:
     def test_join_list_sub_copies_no_qc(
         self, ascii_obs_seq_file_path1, ascii_obs_seq_file_path3
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj3 = obsq.obs_sequence(ascii_obs_seq_file_path3)
-        obs_seq_mega = obsq.obs_sequence.join(
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj3 = obsq.ObsSequence(ascii_obs_seq_file_path3)
+        obs_seq_mega = obsq.ObsSequence.join(
             [obj1, obj3], ["observation", "prior_ensemble_spread"]
         )
 
@@ -489,29 +489,29 @@ class TestJoin:
     def test_join_copies_not_in_all(
         self, ascii_obs_seq_file_path1, ascii_obs_seq_file_path4
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj4 = obsq.obs_sequence(ascii_obs_seq_file_path4)
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj4 = obsq.ObsSequence(ascii_obs_seq_file_path4)
         with pytest.raises(
             ValueError, match="All observation sequences must have the same copies."
         ):
-            obsq.obs_sequence.join([obj1, obj4])
+            obsq.ObsSequence.join([obj1, obj4])
 
     def test_join_copies_not_all_have_subset(
         self, ascii_obs_seq_file_path1, ascii_obs_seq_file_path4
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj4 = obsq.obs_sequence(ascii_obs_seq_file_path4)
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj4 = obsq.ObsSequence(ascii_obs_seq_file_path4)
         with pytest.raises(
             ValueError, match="All observation sequences must have the selected copies."
         ):
-            obsq.obs_sequence.join([obj1, obj4], ["prior_ensemble_member_41"])
+            obsq.ObsSequence.join([obj1, obj4], ["prior_ensemble_member_41"])
 
     def test_join_list_sub_copies(
         self, ascii_obs_seq_file_path1, ascii_obs_seq_file_path3
     ):
-        obj1 = obsq.obs_sequence(ascii_obs_seq_file_path1)
-        obj3 = obsq.obs_sequence(ascii_obs_seq_file_path3)
-        obs_seq_mega = obsq.obs_sequence.join(
+        obj1 = obsq.ObsSequence(ascii_obs_seq_file_path1)
+        obj3 = obsq.ObsSequence(ascii_obs_seq_file_path3)
+        obs_seq_mega = obsq.ObsSequence.join(
             [obj1, obj3], ["prior_ensemble_mean", "observation", "Data_QC"]
         )
         assert obs_seq_mega.has_assimilation_info() == False
@@ -520,7 +520,7 @@ class TestJoin:
 
 class TestCreateHeader:
     def test_create_header(self):
-        obj = obsq.obs_sequence(file=None)
+        obj = obsq.ObsSequence(file=None)
 
         obj.types = {1: "ACARS_BELLYBUTTON", 2: "NCEP_TOES"}
         obj.n_non_qc = 2
@@ -551,7 +551,7 @@ class TestCreateHeader:
 class TestSplitMetadata:
     def test_split_metadata_with_external_FO(self):
         metadata = ["meta1", "meta2", "external_FO1", "meta3", "meta4"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == ["meta1", "meta2"]
@@ -559,7 +559,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_without_external_FO(self):
         metadata = ["meta1", "meta2", "meta3", "meta4"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == ["meta1", "meta2", "meta3", "meta4"]
@@ -567,7 +567,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_multiple_external_FO(self):
         metadata = ["meta1", "external_FO1", "meta2", "external_FO2", "meta3"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == ["meta1"]
@@ -575,7 +575,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_empty_list(self):
         metadata = []
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == []
@@ -583,7 +583,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_no_external_FO(self):
         metadata = ["meta1", "meta2", "meta3"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == ["meta1", "meta2", "meta3"]
@@ -591,7 +591,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_external_FO_at_start(self):
         metadata = ["external_FO1", "meta1", "meta2"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == []
@@ -599,7 +599,7 @@ class TestSplitMetadata:
 
     def test_split_metadata_external_FO_at_end(self):
         metadata = ["meta1", "meta2", "external_FO1"]
-        before_external_FO, after_external_FO = obsq.obs_sequence.split_metadata(
+        before_external_FO, after_external_FO = obsq.ObsSequence.split_metadata(
             metadata
         )
         assert before_external_FO == ["meta1", "meta2"]
@@ -610,7 +610,7 @@ class TestGenerateLinkedListPattern:
     def test_generate_linked_list_pattern(self):
         n = 1
         expected_pattern = ["0           -1         -1"]
-        result = obsq.obs_sequence.generate_linked_list_pattern(n)
+        result = obsq.ObsSequence.generate_linked_list_pattern(n)
         assert result == expected_pattern
 
         n = 3
@@ -619,7 +619,7 @@ class TestGenerateLinkedListPattern:
             "1           3          -1",
             "2           -1         -1",
         ]
-        result = obsq.obs_sequence.generate_linked_list_pattern(n)
+        result = obsq.ObsSequence.generate_linked_list_pattern(n)
         assert result == expected_pattern
 
         n = 6
@@ -631,7 +631,7 @@ class TestGenerateLinkedListPattern:
             "4           6          -1",
             "5           -1         -1",
         ]
-        result = obsq.obs_sequence.generate_linked_list_pattern(n)
+        result = obsq.ObsSequence.generate_linked_list_pattern(n)
         assert result == expected_pattern
 
 
@@ -665,7 +665,7 @@ class TestCreateHeaderFromDataFrame:
         df = pd.DataFrame(data)
 
         # Create an instance of obs_sequence with the sample DataFrame
-        obs_seq = obsq.obs_sequence(file=None)
+        obs_seq = obsq.ObsSequence(file=None)
         obs_seq.df = df
         obs_seq.reverse_types = {
             "ACARS_TEMPERATURE": 1,
@@ -732,7 +732,7 @@ class TestUpdateTypesDicts:
             "52": "PINEAPPLE_COUNT",
         }
 
-        updated_reverse_types, types = obsq.obs_sequence.update_types_dicts(
+        updated_reverse_types, types = obsq.ObsSequence.update_types_dicts(
             sample_df, reverse_types
         )
 
@@ -747,7 +747,7 @@ class TestCompositeTypes:
         file_path = os.path.join(test_dir, "data", "three-obs.final")
 
         # Create an instance of obs_sequence with the 'three-obs.final' file
-        obs_seq = obsq.obs_sequence(file_path)
+        obs_seq = obsq.ObsSequence(file_path)
         return obs_seq
 
     @pytest.mark.parametrize(
@@ -850,7 +850,7 @@ class TestCompositeTypes:
         test_dir = os.path.dirname(__file__)
         file_path = os.path.join(test_dir, "data", "dups-obs.final")
 
-        dup = obsq.obs_sequence(file_path)
+        dup = obsq.ObsSequence(file_path)
         # Test that composite_types raises an error
         with pytest.raises(Exception, match="There are duplicates in the components."):
             dup.composite_types()


### PR DESCRIPTION
obs_sequence class renamed to ObsSequence to follow PEP8 CapWords for [ClassNames](https://peps.python.org/pep-0008/#class-names)

fixes #78