### PR TITLE
function update_attributes_from_df to sync the ObsSequence attributes with the dataFrame

### DIFF
--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -1161,19 +1161,16 @@ class ObsSequence:
         self.n_copies = len(self.copie_names)
 
         # Try to infer non_qc and qc copies from previous names if possible
-        if hasattr(self, "non_qc_copie_names") and hasattr(self, "qc_copie_names"):
-            self.non_qc_copie_names = [
-                c for c in self.copie_names if c in self.non_qc_copie_names
-            ]
-            self.qc_copie_names = [
-                c for c in self.copie_names if c in self.qc_copie_names
-            ]
-        else:
-            # Fallback: treat all as non_qc
+        # Find qc copies first
+        self.qc_copie_names = [c for c in self.copie_names if c in self.qc_copie_names]
+        if self.qc_copie_names == []:  # If no qc copies found, assume all are non-qc
             self.non_qc_copie_names = self.copie_names
-            self.qc_copie_names = []
-        self.n_non_qc = len(self.non_qc_copie_names)
+        else:  # pull out non-qc copies from the copie_names
+            self.non_qc_copie_names = [
+                c for c in self.copie_names if c not in self.qc_copie_names
+            ]
         self.n_qc = len(self.qc_copie_names)
+        self.n_non_qc = len(self.non_qc_copie_names)
 
         # Update types and reverse_types
         if "type" in self.df.columns:

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -1140,7 +1140,7 @@ class ObsSequence:
         self.columns = list(self.df.columns)
 
         # Update all_obs (list of lists, each row) @todo HK do we need this?
-        self.all_obs = self.df.values.tolist() if not self.df.empty else []
+        self.all_obs = None
 
         # Update copie_names, non_qc_copie_names, qc_copie_names, n_copies, n_non_qc, n_qc
         # Try to infer from columns if possible, else leave as is

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -889,7 +889,7 @@ class TestUpdateAttributesFromDf:
 
         # Check initial state
         assert obj.columns == ["obs_num", "observation", "linked_list", "type"]
-        assert obj.all_obs == df1.values.tolist()
+        assert obj.all_obs == None
         assert obj.copie_names == ["observation"]
         assert obj.n_copies == 1
 
@@ -906,7 +906,7 @@ class TestUpdateAttributesFromDf:
 
         # Check updated state
         assert obj.columns == ["obs_num", "observation", "prior_ensemble_mean", "linked_list", "type"]
-        assert obj.all_obs == df2.values.tolist()
+        assert obj.all_obs == None
         assert "prior_ensemble_mean" in obj.copie_names
         assert obj.n_copies == 2  # observation and prior_ensemble_mean
 

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -420,32 +420,14 @@ class TestJoin:
         assert obs_seq_mega.loc_mod == "loc3d"
         assert obs_seq_mega.has_assimilation_info() == True
         assert obs_seq_mega.has_posterior() == False
-        assert list(obs_seq_mega.types.keys()) == list(range(1, 26))  # 25 obs types
+        assert list(obs_seq_mega.types.keys()) == list(range(1, 8))  # 7 obs types
         obs_types = [
-            "AIRCRAFT_TEMPERATURE",
-            "BLUE_LAND_SFC_ALTIMETER",
-            "MARINE_SFC_SPECIFIC_HUMIDITY",
-            "SAT_V_WIND_COMPONENT",
-            "RADIOSONDE_SPECIFIC_HUMIDITY",
-            "MARINE_SFC_TEMPERATURE",
-            "RADIOSONDE_U_WIND_COMPONENT",
-            "MARINE_SFC_ALTIMETER",
-            "AIRCRAFT_V_WIND_COMPONENT",
-            "RADIOSONDE_SURFACE_ALTIMETER",
             "ACARS_TEMPERATURE",
-            "LAND_SFC_ALTIMETER",
-            "MARINE_SFC_V_WIND_COMPONENT",
-            "AIRS_TEMPERATURE",
-            "GPSRO_REFRACTIVITY",
-            "MARINE_SFC_U_WIND_COMPONENT",
             "ACARS_U_WIND_COMPONENT",
-            "RADIOSONDE_V_WIND_COMPONENT",
-            "SAT_U_WIND_COMPONENT",
-            "GREEN_LAND_SFC_ALTIMETER",
             "ACARS_V_WIND_COMPONENT",
-            "RADIOSONDE_TEMPERATURE",
+            "AIRCRAFT_TEMPERATURE",
             "AIRCRAFT_U_WIND_COMPONENT",
-            "AIRS_SPECIFIC_HUMIDITY",
+            "AIRCRAFT_V_WIND_COMPONENT",
             "PINK_LAND_SFC_ALTIMETER",
         ]
         all_obs_present = all(
@@ -727,9 +709,9 @@ class TestUpdateTypesDicts:
             "PINEAPPLE_COUNT": 52,
         }
         expected_types = {
-            32 : "ACARS_TEMPERATURE",
-            51 : "RADIOSONDE_U_WIND_COMPONENT",
-            52 : "PINEAPPLE_COUNT",
+            32: "ACARS_TEMPERATURE",
+            51: "RADIOSONDE_U_WIND_COMPONENT",
+            52: "PINEAPPLE_COUNT",
         }
 
         updated_reverse_types, types = obsq.ObsSequence.update_types_dicts(
@@ -878,12 +860,14 @@ class TestCompositeTypes:
 class TestUpdateAttributesFromDf:
     def test_update_attributes_from_df(self):
         obj = obsq.ObsSequence(file=None)
-        df1 = pd.DataFrame({
-            "obs_num": [1, 2],
-            "observation": [10.0, 20.0],
-            "linked_list": ["-1 2 -1", "1 -1 -1"],
-            "type": ["A", "B"]
-        })
+        df1 = pd.DataFrame(
+            {
+                "obs_num": [1, 2],
+                "observation": [10.0, 20.0],
+                "linked_list": ["-1 2 -1", "1 -1 -1"],
+                "type": ["A", "B"],
+            }
+        )
         obj.df = df1
         obj.update_attributes_from_df()
 
@@ -894,31 +878,41 @@ class TestUpdateAttributesFromDf:
         assert obj.n_copies == 1
 
         # Change the DataFrame
-        df2 = pd.DataFrame({
-            "obs_num": [3],
-            "observation": [30.0],
-            "prior_ensemble_mean": [15.0],
-            "linked_list": ["-1 -1 -1"],
-            "type": ["C"]
-        })
+        df2 = pd.DataFrame(
+            {
+                "obs_num": [3],
+                "observation": [30.0],
+                "prior_ensemble_mean": [15.0],
+                "linked_list": ["-1 -1 -1"],
+                "type": ["C"],
+            }
+        )
         obj.df = df2
         obj.update_attributes_from_df()
 
         # Check updated state
-        assert obj.columns == ["obs_num", "observation", "prior_ensemble_mean", "linked_list", "type"]
+        assert obj.columns == [
+            "obs_num",
+            "observation",
+            "prior_ensemble_mean",
+            "linked_list",
+            "type",
+        ]
         assert obj.all_obs == None
         assert "prior_ensemble_mean" in obj.copie_names
         assert obj.n_copies == 2  # observation and prior_ensemble_mean
 
     def test_update_attributes_from_df_drop_column(self):
         obj = obsq.ObsSequence(file=None)
-        df = pd.DataFrame({
-            "obs_num": [1, 2],
-            "observation": [10.0, 20.0],
-            "prior_ensemble_mean": [1.5, 2.5],
-            "linked_list": ["-1 2 -1", "1 -1 -1"],
-            "type": ["A", "B"]
-        })
+        df = pd.DataFrame(
+            {
+                "obs_num": [1, 2],
+                "observation": [10.0, 20.0],
+                "prior_ensemble_mean": [1.5, 2.5],
+                "linked_list": ["-1 2 -1", "1 -1 -1"],
+                "type": ["A", "B"],
+            }
+        )
         obj.df = df
         obj.update_attributes_from_df()
 
@@ -937,13 +931,15 @@ class TestUpdateAttributesFromDf:
     def test_update_attributes_from_df_qc_counts(self):
         obj = obsq.ObsSequence(file=None)
         # Simulate initial state with one non-QC and one QC copy
-        df = pd.DataFrame({
-            "obs_num": [1, 2],
-            "observation": [10.0, 20.0],
-            "DART_QC": [0, 1],
-            "linked_list": ["-1 2 -1", "1 -1 -1"],
-            "type": ["A", "B"]
-        })
+        df = pd.DataFrame(
+            {
+                "obs_num": [1, 2],
+                "observation": [10.0, 20.0],
+                "DART_QC": [0, 1],
+                "linked_list": ["-1 2 -1", "1 -1 -1"],
+                "type": ["A", "B"],
+            }
+        )
         obj.df = df
         # Manually set up initial copy name classification
         obj.copie_names = ["observation", "DART_QC"]
@@ -973,15 +969,17 @@ class TestUpdateAttributesFromDf:
     def test_update_attributes_from_df_drop_multiple_qc_copies(self):
         obj = obsq.ObsSequence(file=None)
         # Initial DataFrame with 1 non-QC and 3 QC copies
-        df = pd.DataFrame({
-            "obs_num": [1, 2],
-            "observation": [10.0, 20.0],
-            "QC1": [0, 1],
-            "QC2": [1, 0],
-            "QC3": [2, 2],
-            "linked_list": ["-1 2 -1", "1 -1 -1"],
-            "type": ["A", "B"]
-        })
+        df = pd.DataFrame(
+            {
+                "obs_num": [1, 2],
+                "observation": [10.0, 20.0],
+                "QC1": [0, 1],
+                "QC2": [1, 0],
+                "QC3": [2, 2],
+                "linked_list": ["-1 2 -1", "1 -1 -1"],
+                "type": ["A", "B"],
+            }
+        )
         obj.df = df
         obj.copie_names = ["observation", "QC1", "QC2", "QC3"]
         obj.non_qc_copie_names = ["observation"]

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -879,7 +879,9 @@ class TestUpdateAttributesFromDf:
         assert obj.n_copies == 1
         # Check linked_list and obs_num updated
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
         # Change the DataFrame
         df2 = pd.DataFrame(
@@ -908,7 +910,9 @@ class TestUpdateAttributesFromDf:
         assert "prior_ensemble_mean" in obj.copie_names
         assert obj.n_copies == 2  # observation and prior_ensemble_mean
         assert list(obj.df["obs_num"]) == [1]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(1)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(1)
 
     def test_update_attributes_from_df_drop_column(self):
         obj = obsq.ObsSequence(file=None)
@@ -929,7 +933,9 @@ class TestUpdateAttributesFromDf:
         assert "prior_ensemble_mean" in obj.copie_names
         assert obj.n_copies == 2  # observation and prior_ensemble_mean
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
         # Drop a column and update
         obj.df = obj.df.drop(columns=["prior_ensemble_mean"])
@@ -939,7 +945,9 @@ class TestUpdateAttributesFromDf:
         assert "prior_ensemble_mean" not in obj.copie_names
         assert obj.n_copies == 1  # only observation left
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
     def test_update_attributes_from_df_qc_counts(self):
         obj = obsq.ObsSequence(file=None)
@@ -967,7 +975,9 @@ class TestUpdateAttributesFromDf:
         assert obj.non_qc_copie_names == ["observation"]
         assert obj.qc_copie_names == ["DART_QC"]
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
         # Now drop the QC column and update
         obj.df = obj.df.drop(columns=["DART_QC"])
@@ -979,7 +989,9 @@ class TestUpdateAttributesFromDf:
         assert obj.non_qc_copie_names == ["observation"]
         assert obj.qc_copie_names == []
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
     def test_update_attributes_from_df_drop_multiple_qc_copies(self):
         obj = obsq.ObsSequence(file=None)
@@ -1011,7 +1023,9 @@ class TestUpdateAttributesFromDf:
         assert obj.non_qc_copie_names == ["observation"]
         assert obj.qc_copie_names == ["QC1", "QC2", "QC3"]
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
         # Drop two QC columns and update
         obj.df = obj.df.drop(columns=["QC2", "QC3"])
@@ -1024,7 +1038,9 @@ class TestUpdateAttributesFromDf:
         assert obj.qc_copie_names == ["QC1"]
         assert obj.copie_names == ["observation", "QC1"]
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
 
     def test_update_attributes_from_df_drop_row(self):
         obj = obsq.ObsSequence(file=None)
@@ -1034,7 +1050,11 @@ class TestUpdateAttributesFromDf:
                 "observation": [10.0, 20.0, 30.0],
                 "linked_list": ["-1 2 -1", "1 3 -1", "2 -1 -1"],
                 "type": ["A", "B", "C"],
-                "time": [dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 2), dt.datetime(2020, 1, 3)],
+                "time": [
+                    dt.datetime(2020, 1, 1),
+                    dt.datetime(2020, 1, 2),
+                    dt.datetime(2020, 1, 3),
+                ],
             }
         )
         obj.df = df
@@ -1046,10 +1066,52 @@ class TestUpdateAttributesFromDf:
 
         # After dropping, only rows with obs_num 1 and 3 remain, but obs_num should be renumbered
         assert list(obj.df["obs_num"]) == [1, 2]
-        assert list(obj.df["linked_list"]) == obsq.ObsSequence.generate_linked_list_pattern(2)
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
         assert obj.n_copies == 1
+        assert obj.n_qc == 0
+        assert obj.n_non_qc == 1
         assert obj.copie_names == ["observation"]
         assert obj.columns == ["obs_num", "observation", "linked_list", "type", "time"]
+
+    def test_update_attributes_from_df_add_column(self):
+        obj = obsq.ObsSequence(file=None)
+        df = pd.DataFrame(
+            {
+                "obs_num": [1, 2],
+                "observation": [10.0, 20.0],
+                "linked_list": ["-1 2 -1", "1 -1 -1"],
+                "type": ["A", "B"],
+                "time": [dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 2)],
+            }
+        )
+        obj.df = df
+        obj.update_attributes_from_df()
+
+        # Insert a new column between 'observation' and 'linked_list'
+        insert_at = obj.df.columns.get_loc("linked_list")
+        obj.df.insert(insert_at, "prior_ensemble_mean", [1.5, 2.5])
+        obj.update_attributes_from_df()
+
+        # Check that the new column is present and in the correct position
+        assert obj.df.columns.tolist() == [
+            "obs_num",
+            "observation",
+            "prior_ensemble_mean",
+            "linked_list",
+            "type",
+            "time",
+        ]
+        assert "prior_ensemble_mean" in obj.copie_names
+        assert obj.n_copies == 2  # observation and prior_ensemble_mean
+        assert obj.n_qc == 0  # no QC columns
+        assert obj.n_non_qc == 2
+        assert list(obj.df["obs_num"]) == [1, 2]
+        assert list(
+            obj.df["linked_list"]
+        ) == obsq.ObsSequence.generate_linked_list_pattern(2)
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
A function `update_attributes_from_df` to sync the ObsSequence attributes with the dataFrame. 
For operations such as .join or if you want to remove or add a bunch of columns or rows from the dataframe, this function syncs the ObsSequence attributes with the dataframe. 

fixes #81 
fixes #65 

Tests updated:

- test_join_three_obs_seqs.  The types and reverse_types are actually coming from the data frame now, so only the 7 that are in the obs_seq files. 
- New class TestUpdateAttributesFromDf: Testing dropping a column, dropping a qc column, dropping a row


Thinking about:

- self.all_obs :this is hanging out there. I think it does not need to be a class variable, you can always create a list from the dataFrame whenever you want.
-`create_header_from_dataframe`  updates the types dicts, and  `update_attributes_from_df` updates the types dicts and calls `create_header_from_dataframe`
- Should the  update_attributes_from_df called when you write_obs_seq? (Yes? correctness) (No? Performance?)