### PR TITLE
feat: deal with duplicates in composite types

### DIFF
--- a/docs/userguide/statistics.rst
+++ b/docs/userguide/statistics.rst
@@ -82,6 +82,8 @@ Bias is the average difference between the ensemble mean and the observations
    \text{bias} \equiv \frac{1}{N} \sum_{n=1}^{N} ( \mu_n - y_n)
 
 
+.. _stats-multi-comp:
+
 Multi-component Observations
 -----------------------------
 

--- a/docs/userguide/working-with-obsq.rst
+++ b/docs/userguide/working-with-obsq.rst
@@ -222,6 +222,42 @@ In the ObsSequence DataFrame, the type of identity observations is stored as thi
 integer of the index in the DART state vector.
 
 
+Multi-component Observations
+------------------------------
+
+:ref:`stats-multi-comp` are a observations constructed from component observation.
+For example, U and V wind components can be combined into a single observation of horizontal wind speed.
+
+You can create composite observations in your workflow as follows:
+
+.. code-block:: python
+
+    import pydartdiags.obs_sequence.obs_sequence as obsq
+    obs_seq = obsq.ObsSequence('obs_seq.final')
+    obs_seq.composite_types()
+
+The default list of composite observation types is defined in 
+`composite_types.yaml <https://github.com/NCAR/pyDARTdiags/blob/main/src/pydartdiags/obs_sequence/composite_types.yaml>`__
+file. You can give a custom list of composite observation types by passing the path to a YAML file
+to the `composite_types` method:  
+
+.. code-block:: python
+
+    obs_seq.composite_types(composite_types='my_composite_types.yaml')
+
+.. Important::
+
+    By default, duplicate composite observations treated as distinct observations
+    because this is the behavior of the Fortran obs_diag code, which does not look 
+    for nor identify duplicate observations. You can raise an exception if duplicate
+    composite observations are found by passing the `raise_on_duplicate` argument: 
+
+    .. code-block:: python
+
+        obs_seq.composite_types(raise_on_duplicate=True)
+
+    This will raise an exception if duplicate composite observations are found in the observation sequence.
+
 Calculating Statistics
 =======================
 

--- a/docs/userguide/working-with-obsq.rst
+++ b/docs/userguide/working-with-obsq.rst
@@ -225,7 +225,7 @@ integer of the index in the DART state vector.
 Multi-component Observations
 ------------------------------
 
-:ref:`stats-multi-comp` are a observations constructed from component observation.
+:ref:`stats-multi-comp` are a observations constructed from component observations.
 For example, U and V wind components can be combined into a single observation of horizontal wind speed.
 
 You can create composite observations in your workflow as follows:

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -883,23 +883,27 @@ class ObsSequence:
 
                 yield obs
 
-    def composite_types(self, composite_types="use_default"):
+    def composite_types(self, composite_types="use_default", pair_up_duplicates=True):
         """
-        Set up and construct composite types for the DataFrame.
+        Set up and construct composite observation types for the DataFrame.
 
-        This function sets up composite types based on a provided YAML configuration or
+        This function sets up composite observation types based on a provided YAML configuration or
         a default configuration. It constructs new composite rows by combining specified
-        components and adds them to the DataFrame.
+        components and adds them to the DataFrame in place.
 
         Args:
             composite_types (str, optional): The YAML configuration for composite types.
-            If 'use_default', the default configuration is used. Otherwise, a custom YAML configuration can be provided.
+                If 'use_default', the default configuration is used. Otherwise, a custom YAML
+                configuration can be provided.
+            pair_up_duplicates (bool, optional): If False, raises an exception if there are
+                duplicates in the components. otherwise default True, deals with duplicates as though
+                they are distinct observations.
 
         Returns:
             pd.DataFrame: The updated DataFrame with the new composite rows added.
 
         Raises:
-            Exception: If there are repeat values in the components.
+            Exception: If there are repeat values in the components and pair_up_duplicates = False
         """
 
         if composite_types == "use_default":
@@ -925,7 +929,10 @@ class ObsSequence:
         df = pd.DataFrame()
         for key in self.composite_types_dict:
             df_new = construct_composit(
-                df_comp, key, self.composite_types_dict[key]["components"]
+                df_comp,
+                key,
+                self.composite_types_dict[key]["components"],
+                pair_up_duplicates,
             )
             df = pd.concat([df, df_new], axis=0)
 
@@ -1211,24 +1218,31 @@ def convert_dart_time(seconds, days):
     return time
 
 
-def construct_composit(df_comp, composite, components):
+def construct_composit(df_comp, composite, components, pair_up_duplicates):
     """
-    Construct a composite DataFrame by combining rows from two components.
-
-    This function takes two DataFrames and combines rows from them based on matching
-    location and time. It creates a new row with a composite type by combining
-    specified columns using the square root of the sum of squares method.
+    creates a new DataFrame by combining pairs of rows from two specified component
+    types in an observation DataFrame. It matches rows based on location and time,
+    and then combines certain columns using the square root of the sum of squares
+    of the components.
 
     Args:
         df_comp (pd.DataFrame): The DataFrame containing the component rows to be combined.
         composite (str): The type name for the new composite rows.
         components (list of str): A list containing the type names of the two components to be combined.
+        pair_up_duplicates (bool): If False, raises an exception if there are duplicates in the components.
+        otherwise deals with duplicates as though they are distinct observations.
+
 
     Returns:
         merged_df (pd.DataFrame): A DataFrame containing the new composite rows.
     """
+    # select rows for the two components
+    if len(components) != 2:
+        raise ValueError("components must be a list of two component types.")
     selected_rows = df_comp[df_comp["type"] == components[0].upper()]
     selected_rows_v = df_comp[df_comp["type"] == components[1].upper()]
+    selected_rows = selected_rows.copy()
+    selected_rows_v = selected_rows_v.copy()
 
     prior_columns_to_combine = df_comp.filter(regex="prior_ensemble").columns.tolist()
     posterior_columns_to_combine = df_comp.filter(
@@ -1239,7 +1253,7 @@ def construct_composit(df_comp, composite, components):
         + posterior_columns_to_combine
         + ["observation", "obs_err_var"]
     )
-    merge_columns = ["latitude", "longitude", "vertical", "time"]
+    merge_columns = ["latitude", "longitude", "vertical", "time"]  # @todo HK 1d or 3d
     same_obs_columns = merge_columns + [
         "observation",
         "obs_err_var",
@@ -1249,15 +1263,25 @@ def construct_composit(df_comp, composite, components):
         selected_rows[same_obs_columns].duplicated().sum() > 0
         or selected_rows_v[same_obs_columns].duplicated().sum() > 0
     ):
-        print(
-            f"{selected_rows[same_obs_columns].duplicated().sum()} duplicates in {composite} component {components[0]}: "
-        )
-        print(f"{selected_rows[same_obs_columns]}")
-        print(
-            f"{selected_rows_v[same_obs_columns].duplicated().sum()} duplicates in {composite} component {components[0]}: "
-        )
-        print(f"{selected_rows_v[same_obs_columns]}")
-        raise Exception("There are duplicates in the components.")
+
+        if pair_up_duplicates:
+            selected_rows["dup_num"] = selected_rows.groupby(
+                same_obs_columns
+            ).cumcount()
+            selected_rows_v["dup_num"] = selected_rows_v.groupby(
+                same_obs_columns
+            ).cumcount()
+
+        else:
+            print(
+                f"{selected_rows[same_obs_columns].duplicated().sum()} duplicates in {composite} component {components[0]}: "
+            )
+            print(f"{selected_rows[same_obs_columns]}")
+            print(
+                f"{selected_rows_v[same_obs_columns].duplicated().sum()} duplicates in {composite} component {components[0]}: "
+            )
+            print(f"{selected_rows_v[same_obs_columns]}")
+            raise Exception("There are duplicates in the components.")
 
     # Merge the two DataFrames on location and time columns
     merged_df = pd.merge(
@@ -1273,5 +1297,8 @@ def construct_composit(df_comp, composite, components):
     merged_df = merged_df.drop(
         columns=[col for col in merged_df.columns if col.endswith("_v")]
     )
+
+    if "dup_num" in merged_df.columns:
+        merged_df = merged_df.drop(columns=["dup_num"])
 
     return merged_df

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -838,7 +838,7 @@ class TestCompositeTypes:
         dup = obsq.ObsSequence(file_path)
         # Test that composite_types raises an error
         with pytest.raises(Exception, match="There are duplicates in the components."):
-            dup.composite_types(pair_up_duplicates=False)
+            dup.composite_types(raise_on_duplicate=True)
 
     def test_no_yaml_file(self):
         with pytest.raises(Exception):

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -838,7 +838,7 @@ class TestCompositeTypes:
         dup = obsq.ObsSequence(file_path)
         # Test that composite_types raises an error
         with pytest.raises(Exception, match="There are duplicates in the components."):
-            dup.composite_types()
+            dup.composite_types(pair_up_duplicates=False)
 
     def test_no_yaml_file(self):
         with pytest.raises(Exception):

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -943,6 +943,25 @@ class TestCompositeTypes:
         with pytest.raises(yaml.YAMLError):
             obsq.load_yaml_to_dict(broken_file)
 
+    def test_composite_types_more_than_two_components(self, tmpdir):
+        # Create a YAML file with a composite type with more than 2 components
+        composite_yaml = """
+        acars_super_wind:
+            components: [ACARS_U_WIND_COMPONENT, ACARS_V_WIND_COMPONENT, ACARS_TEMPERATURE]
+        """
+        composite_file = tmpdir.join("composite_more_than_two.yaml")
+        with open(composite_file, "w") as f:
+            f.write(composite_yaml)
+
+        test_dir = os.path.dirname(__file__)
+        file_path = os.path.join(test_dir, "data", "three-obs.final")
+        obs_seq = obsq.ObsSequence(file_path)
+        # Should raise an exception due to >2 components
+        with pytest.raises(
+            Exception, match="components must be a list of two component types."
+        ):
+            obs_seq.composite_types(composite_types=str(composite_file))
+
 
 class TestUpdateAttributesFromDf:
     def test_update_attributes_from_df(self):


### PR DESCRIPTION
Composite types: option to raise exception on duplicate observations otherwise (default) treat each duplicate observation as a distinct observation

The default is not to raise an exception on finding duplicates because this is the behavior of the Fortran obs_diag code, which does not look for or identify duplicate observations.

fixes #10