### PR TITLE
Examples for the manipulation of obs sequences by selecting them on a map

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,4 @@ matplotlib
 black
 pytest
 pytest-cov
+dash

--- a/examples/04_interacting/GALLERY_HEADER.rst
+++ b/examples/04_interacting/GALLERY_HEADER.rst
@@ -1,0 +1,8 @@
+
+.. _interact-examples-index:
+
+Interacting with Geographically Plotted Observation Sequences
+=============================================================
+
+Examples of manipulating observation sequences by interacting with observation
+sequence data that has been plotted geographically.

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -27,6 +27,7 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
+
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -28,7 +28,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-# We also create a second obs_seq object to be mainuplated through
+# We also create a second obs_seq object to be manipulated through
 # map selection
 obs_seq = obsq.ObsSequence(data_file)
 obs_seq_selected = obsq.ObsSequence(data_file)
@@ -40,7 +40,7 @@ obs_seq.df.head()
 ###########################################
 # Create and run the interactive Dash app
 # that creates new obs sequence file with
-# observations selcted on geographic plot
+# observations selected on geographic plot
 fig = ip.geo_plot(obs_seq)
 app = ip.include_only_selected_obs_dash_app(fig, obs_seq_selected)
 

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -1,0 +1,48 @@
+"""
+Select observations to add them to a new obs sequence
+=====================================================
+
+This example demonstrates read an observation sequence
+file and launch a Dash app to plot the observations on a map.
+
+You can then select observations on the map to add them to a
+new observation sequence file. Further instructions on usage
+are provided in the Dash app.
+
+"""
+
+###########################################
+# Import the obs_sequence and interactive_plots module
+from pydartdiags.interactive_plots import interactive_plots as ip
+import pydartdiags.obs_sequence.obs_sequence as obsq
+
+###########################################
+# Choose the first obs_seq file to read.
+# In this example, we use a small obs_seq file "obs_seq.final.ascii.medium"
+# that comes with the pyDARTdiags package in the data directory, so we
+# ``import os`` to get the path to the file.
+import os
+data_dir = os.path.join(os.getcwd(), "../..", "data")
+data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
+
+###########################################
+# Read the obs_seq file into an obs_seq object.
+# We also create a second obs_seq object to be mainuplated through
+# map selection
+obs_seq = obsq.obs_sequence(data_file)
+obs_seq_selected = obsq.obs_sequence(data_file)
+
+###########################################
+# Examine the dataframe.
+obs_seq.df.head()
+
+###########################################
+# Create and run the interactive Dash app
+# that creates new obs sequence file with
+# observations selcted on geographic plot
+fig = ip.geo_plot(obs_seq)
+app = ip.include_only_selected_obs_dash_app(fig, obs_seq_selected)
+
+# Run the app
+if __name__ == '__main__':
+    app.run(debug=True, use_reloader=True)

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -9,6 +9,9 @@ You can then select observations on the map to add them to a
 new observation sequence file. Further instructions on usage
 are provided in the Dash app.
 
+Launch the Dash app by executing the 'python3 select_to_pick_obs.py'
+command in your terminal in the /pyDARTdiags/examples/04_interacting
+directory.
 """
 
 ###########################################

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -29,8 +29,8 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 # Read the obs_seq file into an obs_seq object.
 # We also create a second obs_seq object to be mainuplated through
 # map selection
-obs_seq = obsq.obs_sequence(data_file)
-obs_seq_selected = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
+obs_seq_selected = obsq.ObsSequence(data_file)
 
 ###########################################
 # Examine the dataframe.

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -22,6 +22,7 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
+
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
@@ -44,5 +45,5 @@ fig = ip.geo_plot(obs_seq)
 app = ip.include_only_selected_obs_dash_app(fig, obs_seq_selected)
 
 # Run the app
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True, use_reloader=True)

--- a/examples/04_interacting/select_to_pick_obs.py
+++ b/examples/04_interacting/select_to_pick_obs.py
@@ -1,21 +1,23 @@
 """
-Select observations to add them to a new obs sequence
-=====================================================
+Select observations to add them to a new observation sequence
+=============================================================
 
-This example demonstrates read an observation sequence
-file and launch a Dash app to plot the observations on a map.
+This example demonstrates how to read an observation sequence
+file and launch a Dash app to plot those observations on a map.
 
-You can then select observations on the map to add them to a
+You can then select observations on the map and  add them to a
 new observation sequence file. Further instructions on usage
-are provided in the Dash app.
+are provided in the Dash app interface.
 
-Launch the Dash app by executing the 'python3 select_to_pick_obs.py'
-command in your terminal in the /pyDARTdiags/examples/04_interacting
-directory.
+.. image:: ../../../docs/images/pick_obs_image.png
+
+The following program select_to_pick_obs.py uses functions
+already provided in the pyDARTdiags source code to simplify
+the implementation of the Dash app.
 """
 
 ###########################################
-# Import the obs_sequence and interactive_plots module
+# Import the obs_sequence and interactive_plots module.
 from pydartdiags.interactive_plots import interactive_plots as ip
 import pydartdiags.obs_sequence.obs_sequence as obsq
 
@@ -25,14 +27,12 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
-
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
-# Read the obs_seq file into an obs_seq object.
-# We also create a second obs_seq object to be manipulated through
-# map selection
+# Read the obs_seq file into an obs_seq object. Repeat this for a
+# second obs_seq object to be manipulated through map selection.
 obs_seq = obsq.ObsSequence(data_file)
 obs_seq_selected = obsq.ObsSequence(data_file)
 
@@ -41,12 +41,15 @@ obs_seq_selected = obsq.ObsSequence(data_file)
 obs_seq.df.head()
 
 ###########################################
-# Create and run the interactive Dash app
-# that creates new obs sequence file with
-# observations selected on geographic plot
+# Create the interactive Dash app.
 fig = ip.geo_plot(obs_seq)
 app = ip.include_only_selected_obs_dash_app(fig, obs_seq_selected)
 
-# Run the app
+###########################################
+# Run the app.
 if __name__ == "__main__":
     app.run(debug=True, use_reloader=True)
+
+###########################################
+# Launch the Dash app by running the Python program in your terminal
+# using the ``python3 select_to_pick_obs.py`` command.

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -1,21 +1,24 @@
 """
-Select observations to remove them from the obs sequence
-========================================================
+Select observations to remove them from the observation sequence
+================================================================
 
-This example demonstrates read an observation sequence
+This example demonstrates how to read an observation sequence
 file and launch a Dash app to plot the observations on a map.
 
-You can then select observations on the map to add them to a
-new observation sequence file. Further instructions on usage
-are provided in the Dash app.
+You can then select observations on the map and create a
+new observation sequence file that excludes the selected
+observations. Further instructions on usage are provided in the
+Dash app interface.
 
-Launch the Dash app by executing the 'python3 select_to_remove_obs.py'
-command in your terminal in the /pyDARTdiags/examples/04_interacting
-directory.
+.. image:: ../../../docs/images/remove_obs_image.png
+
+The following program select_to_remove_obs.py uses functions
+already provided in the pyDARTdiags source code to simplify
+the implementation of the Dash app.
 """
 
 ###########################################
-# Import the obs_sequence and interactive_plots module
+# Import the obs_sequence and interactive_plots module.
 from pydartdiags.interactive_plots import interactive_plots as ip
 import pydartdiags.obs_sequence.obs_sequence as obsq
 
@@ -25,14 +28,12 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
-
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
-# Read the obs_seq file into an obs_seq object.
-# We also create a second obs_seq object to be manipulated through
-# map selection
+# Read the obs_seq file into an obs_seq object. Repeat this for a
+# second obs_seq object to be manipulated through map selection.
 obs_seq = obsq.ObsSequence(data_file)
 obs_seq_selected = obsq.ObsSequence(data_file)
 
@@ -41,11 +42,15 @@ obs_seq_selected = obsq.ObsSequence(data_file)
 obs_seq.df.head()
 
 ###########################################
-# Create and run the interactive Dash app that creates new obs
-# sequence file with observations selected on geographic plot
+# Create the interactive Dash app.
 fig = ip.geo_plot(obs_seq)
 app = ip.exclude_selected_obs_dash_app(fig, obs_seq_selected)
 
-# Run the app
+###########################################
+# Run the app.
 if __name__ == "__main__":
     app.run(debug=True, use_reloader=True)
+
+###########################################
+# Launch the Dash app by running the Python program in your terminal
+# using the ``python3 select_to_remove_obs.py`` command.

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -1,0 +1,47 @@
+"""
+Select observations to remove them from the obs sequence
+========================================================
+
+This example demonstrates read an observation sequence
+file and launch a Dash app to plot the observations on a map.
+
+You can then select observations on the map to add them to a
+new observation sequence file. Further instructions on usage
+are provided in the Dash app.
+
+"""
+
+###########################################
+# Import the obs_sequence and interactive_plots module
+from pydartdiags.interactive_plots import interactive_plots as ip
+import pydartdiags.obs_sequence.obs_sequence as obsq
+
+###########################################
+# Choose the first obs_seq file to read.
+# In this example, we use a small obs_seq file "obs_seq.final.ascii.medium"
+# that comes with the pyDARTdiags package in the data directory, so we
+# ``import os`` to get the path to the file.
+import os
+data_dir = os.path.join(os.getcwd(), "../..", "data")
+data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
+
+###########################################
+# Read the obs_seq file into an obs_seq object.
+# We also create a second obs_seq object to be mainuplated through 
+# map selection
+obs_seq = obsq.obs_sequence(data_file)
+obs_seq_selected = obsq.obs_sequence(data_file)
+
+###########################################
+# Examine the dataframe.
+obs_seq.df.head()
+
+###########################################
+# Create and run the interactive Dash app that creates new obs
+# sequence file with observations selcted on geographic plot
+fig = ip.geo_plot(obs_seq)
+app = ip.exclude_selected_obs_dash_app(fig, obs_seq_selected)
+
+# Run the app
+if __name__ == '__main__':
+    app.run(debug=True, use_reloader=True)

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -28,6 +28,7 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
+
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -28,7 +28,7 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-# We also create a second obs_seq object to be mainuplated through
+# We also create a second obs_seq object to be manipulated through
 # map selection
 obs_seq = obsq.ObsSequence(data_file)
 obs_seq_selected = obsq.ObsSequence(data_file)
@@ -39,7 +39,7 @@ obs_seq.df.head()
 
 ###########################################
 # Create and run the interactive Dash app that creates new obs
-# sequence file with observations selcted on geographic plot
+# sequence file with observations selected on geographic plot
 fig = ip.geo_plot(obs_seq)
 app = ip.exclude_selected_obs_dash_app(fig, obs_seq_selected)
 

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -22,12 +22,13 @@ import pydartdiags.obs_sequence.obs_sequence as obsq
 # that comes with the pyDARTdiags package in the data directory, so we
 # ``import os`` to get the path to the file.
 import os
+
 data_dir = os.path.join(os.getcwd(), "../..", "data")
 data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 
 ###########################################
 # Read the obs_seq file into an obs_seq object.
-# We also create a second obs_seq object to be mainuplated through 
+# We also create a second obs_seq object to be mainuplated through
 # map selection
 obs_seq = obsq.ObsSequence(data_file)
 obs_seq_selected = obsq.ObsSequence(data_file)
@@ -43,5 +44,5 @@ fig = ip.geo_plot(obs_seq)
 app = ip.exclude_selected_obs_dash_app(fig, obs_seq_selected)
 
 # Run the app
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True, use_reloader=True)

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -9,6 +9,9 @@ You can then select observations on the map to add them to a
 new observation sequence file. Further instructions on usage
 are provided in the Dash app.
 
+Launch the Dash app by executing the 'python3 select_to_remove_obs.py'
+command in your terminal in the /pyDARTdiags/examples/04_interacting
+directory.
 """
 
 ###########################################

--- a/examples/04_interacting/select_to_remove_obs.py
+++ b/examples/04_interacting/select_to_remove_obs.py
@@ -29,8 +29,8 @@ data_file = os.path.join(data_dir, "obs_seq.final.ascii.medium")
 # Read the obs_seq file into an obs_seq object.
 # We also create a second obs_seq object to be mainuplated through 
 # map selection
-obs_seq = obsq.obs_sequence(data_file)
-obs_seq_selected = obsq.obs_sequence(data_file)
+obs_seq = obsq.ObsSequence(data_file)
+obs_seq_selected = obsq.ObsSequence(data_file)
 
 ###########################################
 # Examine the dataframe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "numpy>=1.26",
     "plotly>=5.22.0",
     "pyyaml>=6.0.2",
-    "matplotlib>=3.9.4"
+    "matplotlib>=3.9.4",
+    "dash>=3.1.1"
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "numpy>=1.26",
         "plotly>=5.22.0",
         "pyyaml>=6.0.2",
-        "matplotlib>=3.9.4"
+        "matplotlib>=3.9.4",
+        "dash>=3.1.1"
     ],
 )

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -238,7 +238,7 @@ def exclude_selected_obs_dash_app(fig, obs_seq_selected):
     def update_output(n_clicks, data):
         if n_clicks >= 1:
 
-            # Update the obs_seq_selected dataframe to only include the selected observations
+            # Update the obs_seq_selected dataframe to remove the selected observations
             obs_seq_selected.df = obs_seq_selected.df[
                 ~obs_seq_selected.df["obs_num"].isin(data)
             ]

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -16,19 +16,35 @@ dash_styles = {
 
 def geo_plot(obs_seq):
 
-    fig = px.scatter_geo(
+    # Check if 'DART_quality_control' is a column in the dataframe
+    if 'DART_quality_control' not in obs_seq.df.columns:
+        print("'DART_quality_control' is not used in this obs sequence" \
+                        "file. Color mapping will not be applied.")
+        fig = px.scatter_geo(
         obs_seq.df,
         lat='latitude',
         lon='longitude',
-        color='DART_quality_control',
-        hover_data={'DART_quality_control':True,
-                    'type': True,
+        hover_data={'type': True,
                     'observation': True,
                     'obs_num': True
         },
         width=1400,
         height=850,
     )
+    else:
+        fig = px.scatter_geo(
+            obs_seq.df,
+            lat='latitude',
+            lon='longitude',
+            color='DART_quality_control',
+            hover_data={'DART_quality_control':True,
+                        'type': True,
+                        'observation': True,
+                        'obs_num': True
+            },
+            width=1400,
+            height=850,
+        )
 
     fig.update_layout(clickmode='event+select')
     # If the obs_seq has more than 10,000 observations, do not show hover info

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -22,8 +22,8 @@ def geo_plot(obs_seq):
             lat="latitude",
             lon="longitude",
             hover_data={"type": True, "observation": True, "obs_num": True},
-            width=1400,
-            height=850,
+            width=1600,
+            height=1300,
         )
     else:
         fig = px.scatter_geo(
@@ -40,6 +40,7 @@ def geo_plot(obs_seq):
             width=1400,
             height=850,
         )
+        fig.update_layout(coloraxis_colorbar=dict(len=.8))
 
     fig.update_layout(clickmode="event+select")
     # If the obs_seq has more than 10,000 observations, do not show hover info

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -40,7 +40,7 @@ def geo_plot(obs_seq):
             width=1400,
             height=850,
         )
-        fig.update_layout(coloraxis_colorbar=dict(len=.8))
+        fig.update_layout(coloraxis_colorbar=dict(len=0.8))
 
     fig.update_layout(clickmode="event+select")
     # If the obs_seq has more than 10,000 observations, do not show hover info

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -1,0 +1,219 @@
+from dash import Dash, dcc, html, Input, Output, callback
+import pandas as pd
+import plotly.express as px
+import json
+
+dash_styles = { 
+    'pre': {
+        'border': 'thin lightgrey solid',
+        'overflowX': 'scroll',
+        'color': 'black'
+    },
+    'txt': {
+        'color': 'black'
+    } 
+}
+
+def geo_plot(obs_seq):
+
+    fig = px.scatter_geo(
+        obs_seq.df,
+        lat='latitude',
+        lon='longitude',
+        color='DART_quality_control',
+        hover_data={'DART_quality_control':True,
+                    'type': True,
+                    'observation': True,
+                    'obs_num': True
+        },
+        width=1400,
+        height=850,
+    )
+
+    fig.update_layout(clickmode='event+select')
+    # If the obs_seq has more than 10,000 observations, do not show hover info
+    # to reduce strain on the Dash app
+    if len(obs_seq.df) > 10000:
+        fig.update_traces(hoverinfo='skip', hovertemplate=None)
+
+    return fig
+
+# Creates Dash app to create a new obs_seq file including only
+# the selected obs
+def include_only_selected_obs_dash_app(fig, obs_seq_selected):
+
+    #Initialize the Dash app
+    app = Dash()
+
+    # App layout
+    app.layout = [
+        dcc.Markdown("""
+            ## **Select observations to add them to a new obs sequence**
+
+            Choose the lasso or rectangle tool in the graph's menu
+            bar and then select points in the plot.
+
+            Selection data accumulates if you perform multiple selections,
+            and the currently selected observations will be shown below
+            the plot.
+
+            When you are finished selecting the desired observation, press
+            the select button to create a new observation sequence file
+            that contains only the selected observations.
+
+            To reset the Dash app, simply refresh the page.
+        """, style=dash_styles['txt']),
+
+        dcc.Graph(id='select-obs', figure=fig),
+
+        html.Button('Submit', id='submit-val', n_clicks=0),
+
+        html.Pre(id='confirmation', style=dash_styles['pre']),
+
+        html.Pre(id='selected-data', style=dash_styles['pre']),
+
+        dcc.Store(id="store")
+    ]
+
+    customdata_list = []
+    unique_obs_types = []
+
+    @callback(
+        Output('selected-data', 'children'),
+        Output('store', 'data'),
+        Input('select-obs', 'selectedData'),
+        prevent_initial_call=True
+    )
+    def get_selected_data(selectedData):
+        selected_list = [point['customdata'] for point in selectedData['points']]
+        for item in selected_list:
+            if item not in customdata_list:
+                customdata_list.append(item)
+
+        # Retrieve the observation number and type from customdata_list
+        obs_numbers = [data[-1] for data in customdata_list]
+        obs_types = [data[1] for data in customdata_list]
+
+        # Create list where selected obs types are only included once
+        for item in obs_types:
+            if item not in unique_obs_types:
+                unique_obs_types.append(item)
+
+        # Dump lists to json
+        obs_numbers_json = json.dumps(obs_numbers, indent=2)
+        obs_types_json = json.dumps(unique_obs_types, indent=2)
+
+        # Display info on the selected data in the Dash app
+        return ('Total number of observations selected: ', len(obs_numbers),
+                '\n\nTypes of observations selected: ', obs_types_json,
+                '\n\nSelected observations (obs_num): ', obs_numbers_json), obs_numbers
+
+    @callback(
+        Output('confirmation', 'children'),
+        Input('submit-val', 'n_clicks'),
+        Input('store', 'data'),
+        prevent_initial_call=True
+    )
+    def update_output(n_clicks, data):
+        if n_clicks >=1:
+
+            # Update the obs_seq_selected dataframe to only include the selected observations
+            obs_seq_selected.df = obs_seq_selected.df[obs_seq_selected.df['obs_num'].isin(data)]
+
+            # Write the updated  observation sequence to a file
+            obs_seq_selected.write_obs_seq('./obs_seq.final.'+str(len(data))+'_selected_obs')
+
+            # Display confirmation message in Dash app
+            return 'New observation sequence created with the '+str(len(data))+' selected observations.'
+
+    return app
+
+# Builds a Dash app to create a new obs_seq file excluding
+# the selected obs
+def exclude_selected_obs_dash_app(fig, obs_seq_selected):
+
+    #Initialize the Dash app
+    app = Dash()
+
+    # App layout
+    app.layout = [
+        dcc.Markdown("""
+            ## **Select observations to remove them from the obs sequence**
+
+            Choose the lasso or rectangle tool in the graph's menu
+            bar and then select points in the plot.
+
+            Selection data accumulates if you perform multiple selections,
+            and the currently selected observations will be shown below
+            the plot.
+
+            When you are finished selecting the desired observation, press
+            the select button to create a new observation sequence file
+            that excludes the selected observations.
+
+            To reset the Dash app, simply refresh the page.
+        """, style=dash_styles['txt']),
+
+        dcc.Graph(id='select-obs', figure=fig),
+
+        html.Button('Submit', id='submit-val', n_clicks=0),
+
+        html.Pre(id='confirmation', style=dash_styles['pre']),
+
+        html.Pre(id='selected-data', style=dash_styles['pre']),
+
+        dcc.Store(id="store")
+    ]
+
+    customdata_list = []
+    unique_obs_types = []
+
+    @callback(
+        Output('selected-data', 'children'),
+        Output('store', 'data'),
+        Input('select-obs', 'selectedData'),
+        prevent_initial_call=True
+    )
+    def get_selected_data(selectedData):
+        selected_list = [point['customdata'] for point in selectedData['points']]
+        for item in selected_list:
+            if item not in customdata_list:
+                customdata_list.append(item)
+
+        # Retrieve the observation number and type from customdata_list
+        obs_numbers = [data[-1] for data in customdata_list]
+        obs_types = [data[1] for data in customdata_list]
+
+        # Create list where selected obs types are only included once
+        for item in obs_types:
+            if item not in unique_obs_types:
+                unique_obs_types.append(item)
+
+        # Dump lists to json
+        obs_numbers_json = json.dumps(obs_numbers, indent=2)
+        obs_types_json = json.dumps(unique_obs_types, indent=2)
+
+        # Display info on the selected data in the Dash app
+        return ('Total number of observations selected: ', len(obs_numbers),
+                '\n\nTypes of observations selected: ', obs_types_json,
+                '\n\nSelected observations (obs_num): ', obs_numbers_json), obs_numbers
+
+    @callback(
+        Output('confirmation', 'children'),
+        Input('submit-val', 'n_clicks'),
+        Input('store', 'data'),
+        prevent_initial_call=True
+    )
+    def update_output(n_clicks, data):
+        if n_clicks >=1:
+
+            # Update the obs_seq_selected dataframe to only include the selected observations
+            obs_seq_selected.df = obs_seq_selected.df[~obs_seq_selected.df['obs_num'].isin(data)]
+
+            # Write the updated  observation sequence to a file
+            obs_seq_selected.write_obs_seq('./obs_seq.final.excluding_'+str(len(data))+'_selected_obs')
+
+            # Display confirmation message in Dash app
+            return 'New observation sequence created with the '+str(len(data))+' selected observations removed.'
+
+    return app

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -88,7 +88,7 @@ def include_only_selected_obs_dash_app(fig, obs_seq_selected):
     customdata_list = []
     unique_obs_types = []
 
-    @callback(
+    @app.callback(
         Output("selected-data", "children"),
         Output("store", "data"),
         Input("select-obs", "selectedData"),
@@ -123,7 +123,7 @@ def include_only_selected_obs_dash_app(fig, obs_seq_selected):
             obs_numbers_json,
         ), obs_numbers
 
-    @callback(
+    @app.callback(
         Output("confirmation", "children"),
         Input("submit-val", "n_clicks"),
         Input("store", "data"),
@@ -190,7 +190,7 @@ def exclude_selected_obs_dash_app(fig, obs_seq_selected):
     customdata_list = []
     unique_obs_types = []
 
-    @callback(
+    @app.callback(
         Output("selected-data", "children"),
         Output("store", "data"),
         Input("select-obs", "selectedData"),
@@ -225,7 +225,7 @@ def exclude_selected_obs_dash_app(fig, obs_seq_selected):
             obs_numbers_json,
         ), obs_numbers
 
-    @callback(
+    @app.callback(
         Output("confirmation", "children"),
         Input("submit-val", "n_clicks"),
         Input("store", "data"),

--- a/src/pydartdiags/interactive_plots/interactive_plots.py
+++ b/src/pydartdiags/interactive_plots/interactive_plots.py
@@ -74,7 +74,9 @@ def include_only_selected_obs_dash_app(fig, obs_seq_selected):
             the select button to create a new observation sequence file
             that contains only the selected observations.
 
-            To reset the Dash app, simply refresh the page.
+            To reset the Dash app, quit the app by pressing Ctrl+C and
+            restart it by executing the command 'python3 select_to_pick_obs.py'
+            in your terminal.
         """,
             style=dash_styles["txt"],
         ),
@@ -176,7 +178,9 @@ def exclude_selected_obs_dash_app(fig, obs_seq_selected):
             the select button to create a new observation sequence file
             that excludes the selected observations.
 
-            To reset the Dash app, simply refresh the page.
+            To reset the Dash app, quit the app by pressing Ctrl+C and
+            restart it by executing the command 'python3 select_to_remove_obs.py'
+            in your terminal.
         """,
             style=dash_styles["txt"],
         ),

--- a/tests/test_interactive_plots.py
+++ b/tests/test_interactive_plots.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import json
+import pandas as pd
+from pydartdiags.obs_sequence import obs_sequence as obsq
+from pydartdiags.interactive_plots import interactive_plots as ip
+
+
+class TestGeoPlot:
+    @pytest.fixture
+    def obs_seq(self):
+        # Sample dataframe for testing
+        data = {
+            "latitude": [10.0, 20.0, 30.0],
+            "longitude": [40.0, 50.0, 60.0],
+            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "observation": [1.0, 2.0, 3.0],
+            "obs_num": [1001, 1002, 1003],
+            "DART_quality_control": [0, 1, 2],
+        }
+        df = pd.DataFrame(data)
+
+        # Create an instance of obs_sequence with the sample DataFrame
+        obs_seq = obsq.ObsSequence(file=None)
+        obs_seq.df = df
+        return obs_seq
+
+    @pytest.fixture
+    def obs_seq_no_qc(self):
+        # Sample dataframe without 'DART_quality_control' column
+        data = {
+            "latitude": [10.0, 20.0, 30.0],
+            "longitude": [40.0, 50.0, 60.0],
+            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "observation": [1.0, 2.0, 3.0],
+            "obs_num": [1001, 1002, 1003],
+        }
+        df = pd.DataFrame(data)
+
+        # Create an instance of obs_sequence with the sample DataFrame
+        obs_seq_no_qc = obsq.ObsSequence(file=None)
+        obs_seq_no_qc.df = df
+        return obs_seq_no_qc
+
+    def test_geo_plot_with_qc(self, obs_seq):
+        fig = ip.geo_plot(obs_seq)
+        # Check that a figure is returned
+        assert fig is not None
+        # Check that the hover template includes 'DART_quality_control'
+        assert "DART_quality_control" in fig.data[0].hovertemplate
+        # Check that the figure has data
+        assert len(fig.data) > 0
+
+    def test_geo_plot_without_qc(self, obs_seq_no_qc):
+        fig = ip.geo_plot(obs_seq_no_qc)
+        # Check that a figure is returned
+        assert fig is not None
+        # Check that the hover template includes 'DART_quality_control'
+        assert "DART_quality_control" not in fig.data[0].hovertemplate
+        # Check that the figure has data
+        assert len(fig.data) > 0
+
+class TestDashApps:
+    @pytest.fixture
+    def obs_seq(self):
+        # Sample dataframe for testing
+        data = {
+            "latitude": [10.0, 20.0, 30.0],
+            "longitude": [40.0, 50.0, 60.0],
+            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "observation": [1.0, 2.0, 3.0],
+            "obs_num": [1001, 1002, 1003],
+            "DART_quality_control": [0, 1, 2]
+        }
+        df = pd.DataFrame(data)
+
+        # Create an instance of obs_sequence with the sample DataFrame
+        obs_seq = obsq.ObsSequence(file=None)
+        obs_seq.df = df
+        return obs_seq
+
+    def test_include_only_selected_obs_dash_app(self, obs_seq):
+        # Create a copy of the obs_seq for selection
+        obs_seq_selected = obsq.ObsSequence(file=None)
+        obs_seq_selected.df = obs_seq.df.copy()
+
+        # Create the figure for the Dash app
+        fig = ip.geo_plot(obs_seq)
+        app = ip.include_only_selected_obs_dash_app(fig, obs_seq_selected)
+
+        # Simulate selecting observations
+        selected_data = {"points": [{"customdata": [10.0, "ACARS_TEMPERATURE", 1001]}]}
+
+        predetermined_output_selected_data = [
+            "Total number of observations selected: ",
+            1,
+            "\n\nTypes of observations selected: ",
+            "[\n  \"ACARS_TEMPERATURE\"\n]",
+            "\n\nSelected observations (obs_num): ",
+            "[\n  1001\n]"
+            ]
+        predetermined_output_store = [1001]
+
+        # Use the callback map to get the output from get_selected_data
+        callback = app.callback_map["..selected-data.children...store.data.."]["callback"]
+        outputs_list = [{"id": "selected-data", "property": "children"}, {"id": "store", "property": "data"}]
+        full_output = callback(selected_data, outputs_list=outputs_list)
+        output_json = json.loads(full_output)
+
+        # Verify selected-data and store outputs
+        assert(output_json["response"]["selected-data"]["children"] == predetermined_output_selected_data)
+        assert(output_json["response"]["store"]["data"] == predetermined_output_store)
+
+    def test_exclude_selected_obs_dash_app(self, obs_seq):
+        # Create a copy of the obs_seq for selection
+        obs_seq_selected = obsq.ObsSequence(file=None)
+        obs_seq_selected.df = obs_seq.df.copy()
+
+        # Create the figure for the Dash app
+        fig = ip.geo_plot(obs_seq)
+        app = ip.exclude_selected_obs_dash_app(fig, obs_seq_selected)
+
+        # Simulate selecting observations
+        selected_data = {"points": [{"customdata": [10.0, "ACARS_TEMPERATURE", 1001]}]}
+
+        predetermined_output_selected_data = [
+            "Total number of observations selected: ",
+            1,
+            "\n\nTypes of observations selected: ",
+            "[\n  \"ACARS_TEMPERATURE\"\n]",
+            "\n\nSelected observations (obs_num): ",
+            "[\n  1001\n]"
+            ]
+        predetermined_output_store = [1001]
+
+        # Use the callback map to get the output from get_selected_data
+        callback = app.callback_map["..selected-data.children...store.data.."]["callback"]
+        outputs_list = [{"id": "selected-data", "property": "children"}, {"id": "store", "property": "data"}]
+        full_output = callback(selected_data, outputs_list=outputs_list)
+        output_json = json.loads(full_output)
+
+        # Verify selected-data and store outputs
+        assert(output_json["response"]["selected-data"]["children"] == predetermined_output_selected_data)
+        assert(output_json["response"]["store"]["data"] == predetermined_output_store)

--- a/tests/test_interactive_plots.py
+++ b/tests/test_interactive_plots.py
@@ -13,7 +13,11 @@ class TestGeoPlot:
         data = {
             "latitude": [10.0, 20.0, 30.0],
             "longitude": [40.0, 50.0, 60.0],
-            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "type": [
+                "ACARS_TEMPERATURE",
+                "RADIOSONDE_U_WIND_COMPONENT",
+                "ACARS_TEMPERATURE",
+            ],
             "observation": [1.0, 2.0, 3.0],
             "obs_num": [1001, 1002, 1003],
             "DART_quality_control": [0, 1, 2],
@@ -31,7 +35,11 @@ class TestGeoPlot:
         data = {
             "latitude": [10.0, 20.0, 30.0],
             "longitude": [40.0, 50.0, 60.0],
-            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "type": [
+                "ACARS_TEMPERATURE",
+                "RADIOSONDE_U_WIND_COMPONENT",
+                "ACARS_TEMPERATURE",
+            ],
             "observation": [1.0, 2.0, 3.0],
             "obs_num": [1001, 1002, 1003],
         }
@@ -60,6 +68,7 @@ class TestGeoPlot:
         # Check that the figure has data
         assert len(fig.data) > 0
 
+
 class TestDashApps:
     @pytest.fixture
     def obs_seq(self):
@@ -67,10 +76,14 @@ class TestDashApps:
         data = {
             "latitude": [10.0, 20.0, 30.0],
             "longitude": [40.0, 50.0, 60.0],
-            "type": ["ACARS_TEMPERATURE", "RADIOSONDE_U_WIND_COMPONENT", "ACARS_TEMPERATURE"],
+            "type": [
+                "ACARS_TEMPERATURE",
+                "RADIOSONDE_U_WIND_COMPONENT",
+                "ACARS_TEMPERATURE",
+            ],
             "observation": [1.0, 2.0, 3.0],
             "obs_num": [1001, 1002, 1003],
-            "DART_quality_control": [0, 1, 2]
+            "DART_quality_control": [0, 1, 2],
         }
         df = pd.DataFrame(data)
 
@@ -95,21 +108,29 @@ class TestDashApps:
             "Total number of observations selected: ",
             1,
             "\n\nTypes of observations selected: ",
-            "[\n  \"ACARS_TEMPERATURE\"\n]",
+            '[\n  "ACARS_TEMPERATURE"\n]',
             "\n\nSelected observations (obs_num): ",
-            "[\n  1001\n]"
-            ]
+            "[\n  1001\n]",
+        ]
         predetermined_output_store = [1001]
 
         # Use the callback map to get the output from get_selected_data
-        callback = app.callback_map["..selected-data.children...store.data.."]["callback"]
-        outputs_list = [{"id": "selected-data", "property": "children"}, {"id": "store", "property": "data"}]
+        callback = app.callback_map["..selected-data.children...store.data.."][
+            "callback"
+        ]
+        outputs_list = [
+            {"id": "selected-data", "property": "children"},
+            {"id": "store", "property": "data"},
+        ]
         full_output = callback(selected_data, outputs_list=outputs_list)
         output_json = json.loads(full_output)
 
         # Verify selected-data and store outputs
-        assert(output_json["response"]["selected-data"]["children"] == predetermined_output_selected_data)
-        assert(output_json["response"]["store"]["data"] == predetermined_output_store)
+        assert (
+            output_json["response"]["selected-data"]["children"]
+            == predetermined_output_selected_data
+        )
+        assert output_json["response"]["store"]["data"] == predetermined_output_store
 
     def test_exclude_selected_obs_dash_app(self, obs_seq):
         # Create a copy of the obs_seq for selection
@@ -127,18 +148,26 @@ class TestDashApps:
             "Total number of observations selected: ",
             1,
             "\n\nTypes of observations selected: ",
-            "[\n  \"ACARS_TEMPERATURE\"\n]",
+            '[\n  "ACARS_TEMPERATURE"\n]',
             "\n\nSelected observations (obs_num): ",
-            "[\n  1001\n]"
-            ]
+            "[\n  1001\n]",
+        ]
         predetermined_output_store = [1001]
 
         # Use the callback map to get the output from get_selected_data
-        callback = app.callback_map["..selected-data.children...store.data.."]["callback"]
-        outputs_list = [{"id": "selected-data", "property": "children"}, {"id": "store", "property": "data"}]
+        callback = app.callback_map["..selected-data.children...store.data.."][
+            "callback"
+        ]
+        outputs_list = [
+            {"id": "selected-data", "property": "children"},
+            {"id": "store", "property": "data"},
+        ]
         full_output = callback(selected_data, outputs_list=outputs_list)
         output_json = json.loads(full_output)
 
         # Verify selected-data and store outputs
-        assert(output_json["response"]["selected-data"]["children"] == predetermined_output_selected_data)
-        assert(output_json["response"]["store"]["data"] == predetermined_output_store)
+        assert (
+            output_json["response"]["selected-data"]["children"]
+            == predetermined_output_selected_data
+        )
+        assert output_json["response"]["store"]["data"] == predetermined_output_store


### PR DESCRIPTION
These two examples launch Dash apps, which plot observations in a sequence on a map, and allows users to draw a shape on a map to select observations in the region. 

Once obs are selected, they can either be removed from the current obs sequence or added to a new one. The resulting obs seqs are then saved in examples/04_interacting 

![image](https://github.com/user-attachments/assets/3f33c9a5-4918-45aa-a244-6c19425fe86b)

Also adds new source code dir interactive_plots