### PR TITLE
Fix plot rh for ocean obs

### DIFF
--- a/src/pydartdiags/stats/stats.py
+++ b/src/pydartdiags/stats/stats.py
@@ -230,7 +230,7 @@ def bin_by_layer(df, levels, verticalUnit="pressure (Pa)"):
     """
     pd.options.mode.copy_on_write = True
     df.loc[df["vert_unit"] == verticalUnit, "vlevels"] = pd.cut(
-        df.loc[df["vert_unit"] == verticalUnit, "vertical"], levels
+        df.loc[df["vert_unit"] == verticalUnit, "vertical"], levels, include_lowest=True
     )
     df.loc[:, "midpoint"] = df["vlevels"].apply(lambda x: x.mid)
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -44,7 +44,6 @@ class TestRankCalculation:
 
         # Call the function
         df_hist = stats.calculate_rank(df)
-        print(df_hist.columns)
 
         # HK @todo need a random number test to check the rank calculation
         assert "prior_rank" in df_hist.columns
@@ -438,7 +437,7 @@ class TestPossibleVsUsed:
         df = pd.DataFrame(data)
 
         # Define the layers
-        layers = [0, 100, 200, 300]  # midpoints are 50, 150, 250
+        layers = [0, 100, 200, 300]  # midpoints are 49.999, 150, 250
         stats.bin_by_layer(df, layers)
 
         # Call the function
@@ -450,8 +449,8 @@ class TestPossibleVsUsed:
 
         # Check the values of the new columns
         expected_midpoints = pd.Categorical(
-            [50.0, 150.0, 250.0, 50.0, 150.0, 250.0],
-            categories=[50.0, 150.0, 250.0],
+            [49.9995, 150.0, 250.0, 49.9995, 150.0, 250.0],
+            categories=[49.9995, 150.0, 250.0],
             ordered=True,
         )
         expected_data = {
@@ -544,23 +543,23 @@ class TestLayers:
         # Check the values of the new columns: vlevels and midpoint
         expected_vlevels = pd.Categorical(
             [
-                pd.Interval(left=0, right=100, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
-                pd.Interval(left=100, right=200, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
+                pd.Interval(left=-0.001, right=100.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
+                pd.Interval(left=100.0, right=200.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
             ],
             categories=[
-                pd.Interval(left=0, right=100, closed="right"),
-                pd.Interval(left=100, right=200, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
+                pd.Interval(left=-0.001, right=100.0, closed="right"),
+                pd.Interval(left=100.0, right=200.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
             ],
             ordered=True,
         )
 
         expected_midpoints = pd.Categorical(
-            [50.0, 250.0, 150.0, 250.0, 250.0],
-            categories=[50.0, 150.0, 250.0],
+            [49.9995, 250.0, 150.0, 250.0, 250.0],
+            categories=[49.9995, 150.0, 250.0],
             ordered=True,
         )
         data_result = {
@@ -619,23 +618,23 @@ class TestLayers:
         # Check the values of the new columns: vlelvels and midpoint
         expected_vlevels = pd.Categorical(
             [
-                pd.Interval(left=0, right=100, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
-                pd.Interval(left=100, right=200, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
+                pd.Interval(left=-0.001, right=100.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
+                pd.Interval(left=100.0, right=200.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
             ],
             categories=[
-                pd.Interval(left=0, right=100, closed="right"),
-                pd.Interval(left=100, right=200, closed="right"),
-                pd.Interval(left=200, right=300, closed="right"),
+                pd.Interval(left=-0.001, right=100.0, closed="right"),
+                pd.Interval(left=100.0, right=200.0, closed="right"),
+                pd.Interval(left=200.0, right=300.0, closed="right"),
             ],
             ordered=True,
         )
 
         expected_midpoints = pd.Categorical(
-            [50.0, 250.0, 150.0, 250.0, 250.0],
-            categories=[50.0, 150.0, 250.0],
+            [49.9995, 250.0, 150.0, 250.0, 250.0],
+            categories=[49.9995, 150.0, 250.0],
             ordered=True,
         )
         data_result = {


### PR DESCRIPTION
Fixes #105 

* Check vertical is all in same unit before binning
* Includes lower bound on level, ocean obs often have 0m. Not this makes the midpoint ugly 9.9995
* Adds a flag for depth(m) unit rather than height (m) @hkershaw-brown this should go on profile too? (yes)

Not sure about the top boundary, set by user, do we want to use max value of depth/height?

