### PR TITLE
info routine to display info about the ObsSequence

### DIFF
--- a/docs/api/obs_sequence.rst
+++ b/docs/api/obs_sequence.rst
@@ -83,6 +83,7 @@ all_obs
 ObsSequence Methods
 =======================
 
+.. automethod:: obs_sequence.ObsSequence.info
 .. automethod:: obs_sequence.ObsSequence.write_obs_seq 
 .. automethod:: obs_sequence.ObsSequence.possible_vs_used
 .. automethod:: obs_sequence.ObsSequence.select_by_dart_qc

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -6,6 +6,7 @@ import os
 import yaml
 import struct
 import functools
+import inspect
 
 
 def _requires_assimilation_info(func):
@@ -158,6 +159,40 @@ class ObsSequence:
         # Replace MISSING_R8s with NaNs in posterior stats where DART_quality_control = 2
         if self.has_posterior():
             ObsSequence._replace_qc2_nan(self.df)
+
+    def info(self):
+        """Print all data attributes and public methods of this ObsSequence."""
+        routines = []
+        non_routines = []
+        for attr in dir(self):
+            if attr.startswith("_"):
+                continue
+            value = getattr(self, attr)
+            if callable(value):
+                routines.append(attr)
+            else:
+                non_routines.append((attr, value))
+        print("Non-routines (data attributes):")
+        for name, value in non_routines:
+            if isinstance(value, pd.DataFrame):
+                print(f"  - {name}: DataFrame{value.shape}")
+            else:
+                print(f"  - {name}: {value}")
+        print("\nRoutines (methods/functions):")
+        for r in routines:
+            print(f"  - {r}")
+
+    def __repr__(self):
+        return f"ObsSequence(file={self.file!r})"
+
+    def __str__(self):
+        return (
+            f"ObsSequence: {self.file}\n"
+            f"  obs types : {list(self.types.keys())}\n"
+            f"  copies    : {self.copie_names}\n"
+            f"  n_obs     : {len(self.df)}\n"
+            f"  loc mod   : {self.loc_mod}"
+        )
 
     def _create_all_obs(self):
         """steps through the generator to create a

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -554,6 +554,36 @@ class TestCreateHeader:
         assert obj.header == expected_header
 
 
+class TestDisplayInfo:
+    @pytest.fixture
+    def obs_seq(self):
+        obj = obsq.ObsSequence(file=None)
+        obj.types = {"RADIOSONDE_TEMPERATURE": 1}
+        obj.copie_names = ["observation", "DART_quality_control"]
+        obj.loc_mod = "loc3d"
+        obj.df = pd.DataFrame({"observation": [1.0, 2.0]})
+        return obj
+
+    def test_repr(self, obs_seq):
+        assert repr(obs_seq) == "ObsSequence(file=None)"
+
+    def test_str(self, obs_seq):
+        result = str(obs_seq)
+        assert "ObsSequence" in result
+        assert "RADIOSONDE_TEMPERATURE" in result
+        assert "observation" in result
+        assert "2" in result  # n_obs
+        assert "loc3d" in result  # loc_mod
+
+    def test_info(self, obs_seq, capsys):
+        obs_seq.info()
+        captured = capsys.readouterr()
+        assert "Routines (methods/functions):" in captured.out
+        assert "Non-routines (data attributes):" in captured.out
+        assert "df" in captured.out
+        assert "info" in captured.out
+
+
 class TestSplitMetadata:
     def test_split_metadata_with_external_FO(self):
         metadata = ["meta1", "meta2", "external_FO1", "meta3", "meta4"]


### PR DESCRIPTION
__repl__ and __str__ also

fixes #92

Example:

```
>>> import pydartdiags.obs_sequence.obs_sequence as obsq
>>> obs_seq = obsq.ObsSequence(file=None)
>>> obs_seq
ObsSequence(file=None)
>>> print(obs_seq)
ObsSequence: None
  obs types : []
  copies    : []
  n_obs     : 0
>>> obs_seq.info()
Non-routines (data attributes):
  - all_obs: []
  - copie_names: []
  - default_composite_types: /Users/hkershaw/DART/siparcs/2026/pyDARTdiags/src/pydartdiags/obs_sequence/composite_types.yaml
  - df: DataFrame(0, 0)
  - file: None
  - loc_mod: None
  - n_copies: 0
  - n_non_qc: 0
  - n_qc: 0
  - non_qc_copie_names: []
  - qc_copie_names: []
  - reverse_types: {}
  - reversed_vert: {'undefined': -2, 'surface (m)': -1, 'model level': 1, 'pressure (Pa)': 2, 'height (m)': 3, 'scale height': 4}
  - seq: []
  - synonyms_for_obs: ['NCEP BUFR observation', 'AIRS observation', 'GTSPP observation', 'SST observation', 'observations', 'WOD observation']
  - types: {}
  - vert: {-2: 'undefined', -1: 'surface (m)', 1: 'model level', 2: 'pressure (Pa)', 3: 'height (m)', 4: 'scale height'}

Routines (methods/functions):
  - composite_types
  - create_header
  - create_header_from_dataframe
  - has_assimilation_info
  - has_posterior
  - info
  - join
  - possible_vs_used
  - select_by_dart_qc
  - select_used_qcs
  - update_attributes_from_df
  - write_obs_seq
 ```

This example is a black obs seq so boring.