### PR TITLE
Adds "convert_to_dart_time" function

### DIFF
--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -1263,7 +1263,7 @@ def _load_yaml_to_dict(file_path):
         raise
 
 
-def _convert_dart_time(seconds, days):
+def _convert_from_dart_time(seconds, days):
     """covert from seconds, days after 1601 to datetime object
 
     Note:
@@ -1273,6 +1273,10 @@ def _convert_dart_time(seconds, days):
     time = dt.datetime(1601, 1, 1) + dt.timedelta(days=days, seconds=seconds)
     return time
 
+def convert_to_dart_time(time: dt.datetime):
+    """Converts datetime object to a list of seconds, days after 1601"""
+    dart_time = time - dt.datetime(1601, 1, 1)
+    return [dart_time.seconds, dart_time.days]
 
 def _construct_composit(df_comp, composite, components, raise_on_duplicate):
     """

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -1263,7 +1263,7 @@ def _load_yaml_to_dict(file_path):
         raise
 
 
-def _convert_from_dart_time(seconds, days):
+def _convert_dart_time(seconds, days):
     """covert from seconds, days after 1601 to datetime object
 
     Note:
@@ -1273,7 +1273,7 @@ def _convert_from_dart_time(seconds, days):
     time = dt.datetime(1601, 1, 1) + dt.timedelta(days=days, seconds=seconds)
     return time
 
-def convert_to_dart_time(time: dt.datetime):
+def _convert_to_dart_time(time: dt.datetime):
     """Converts datetime object to a list of seconds, days after 1601"""
     dart_time = time - dt.datetime(1601, 1, 1)
     return [dart_time.seconds, dart_time.days]

--- a/src/pydartdiags/obs_sequence/obs_sequence.py
+++ b/src/pydartdiags/obs_sequence/obs_sequence.py
@@ -1273,10 +1273,12 @@ def _convert_dart_time(seconds, days):
     time = dt.datetime(1601, 1, 1) + dt.timedelta(days=days, seconds=seconds)
     return time
 
+
 def _convert_to_dart_time(time: dt.datetime):
     """Converts datetime object to a list of seconds, days after 1601"""
     dart_time = time - dt.datetime(1601, 1, 1)
     return [dart_time.seconds, dart_time.days]
+
 
 def _construct_composit(df_comp, composite, components, raise_on_duplicate):
     """

--- a/tests/test_obs_sequence.py
+++ b/tests/test_obs_sequence.py
@@ -32,6 +32,26 @@ class TestConvertDartTime:
         assert result == expected
 
 
+class TestConvertToDartTime:
+    def test_epoch(self):
+        result = obsq._convert_to_dart_time(dt.datetime(1601, 1, 1))
+        assert result == [0, 0]
+
+    def test_one_day_as_seconds(self):
+        result = obsq._convert_to_dart_time(dt.datetime(1601, 1, 2))
+        assert result == [0, 1]
+
+    def test_known_dart_time(self):
+        result = obsq._convert_to_dart_time(dt.datetime(2015, 1, 31, 0, 36, 4))
+        assert result == [2164, 151240]
+
+    def test_roundtrip(self):
+        seconds, days = 2164, 151240
+        datetime_obj = obsq._convert_dart_time(seconds, days)
+        result = obsq._convert_to_dart_time(datetime_obj)
+        assert result == [seconds, days]
+
+
 class TestSanitizeInput:
     @pytest.fixture
     def bad_loc_file_path(self):


### PR DESCRIPTION
Adds a function to obs_sequence.py (in the obs_sequence module) converting a datetime object to DART readable time (seconds and days since 1601) as a list with two elements.